### PR TITLE
Harden Scopus retrieval: HTTP timeouts, connection cleanup, XXE-safe parsing

### DIFF
--- a/src/main/java/reciter/scopus/callable/ScopusUriParserCallable.java
+++ b/src/main/java/reciter/scopus/callable/ScopusUriParserCallable.java
@@ -1,11 +1,14 @@
 package reciter.scopus.callable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -14,6 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 import reciter.model.scopus.ScopusArticle;
 import reciter.scopus.xmlparser.ScopusXmlHandler;
@@ -21,31 +26,70 @@ import reciter.scopus.xmlparser.ScopusXmlHandler;
 public class ScopusUriParserCallable implements Callable<List<ScopusArticle>> {
 
 	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusUriParserCallable.class);
-	
+
 	private static final String INST_TOKEN = System.getenv("SCOPUS_INST_TOKEN");
 	private static final String API_KEY = System.getenv("SCOPUS_API_KEY");
-	
+
+	private static final int CONNECT_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(15);
+	private static final int READ_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(120);
+
+	/**
+	 * Shared, XXE-hardened SAX parser factory. {@code SAXParserFactory} configuration is
+	 * not thread-safe, but it is configured once here and {@link #newHardenedParser()}
+	 * synchronizes the {@code newSAXParser()} call; each {@link SAXParser} is then used by
+	 * a single thread.
+	 */
+	private static final SAXParserFactory SAX_PARSER_FACTORY = createHardenedFactory();
+
 	private final ScopusXmlHandler xmlHandler;
 	private final String uri;
-	
+
 	public ScopusUriParserCallable(ScopusXmlHandler xmlHandler, String uri) {
 		this.xmlHandler = xmlHandler;
 		this.uri = uri;
 	}
-	
+
+	private static SAXParserFactory createHardenedFactory() {
+		SAXParserFactory factory = SAXParserFactory.newInstance();
+		try {
+			// Block DTDs entirely (Scopus responses contain none) — the strongest XXE defense.
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setXIncludeAware(false);
+		} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+			slf4jLogger.warn("Could not fully harden SAX parser factory against XXE: {}", e.getMessage());
+		}
+		return factory;
+	}
+
+	private static SAXParser newHardenedParser() throws ParserConfigurationException, SAXException {
+		synchronized (SAX_PARSER_FACTORY) {
+			return SAX_PARSER_FACTORY.newSAXParser();
+		}
+	}
+
 	public List<ScopusArticle> parse(String uri) throws ParserConfigurationException, SAXException, IOException {
 		URL url = new URL(uri);
 		slf4jLogger.info(url.toString());
 		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-		conn.setRequestMethod("GET");
-		conn.setRequestProperty("Accept", "application/xml");
-		conn.setRequestProperty("X-ELS-Insttoken", INST_TOKEN);
-		conn.setRequestProperty("X-ELS-APIKey", API_KEY);
-		
-		InputSource source = new InputSource(conn.getInputStream());
-		
-		SAXParser saxParser = SAXParserFactory.newInstance().newSAXParser();
-		saxParser.parse(source, xmlHandler);
+		try {
+			conn.setRequestMethod("GET");
+			conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+			conn.setReadTimeout(READ_TIMEOUT_MS);
+			conn.setRequestProperty("Accept", "application/xml");
+			conn.setRequestProperty("X-ELS-Insttoken", INST_TOKEN);
+			conn.setRequestProperty("X-ELS-APIKey", API_KEY);
+
+			SAXParser saxParser = newHardenedParser();
+			try (InputStream in = conn.getInputStream()) {
+				saxParser.parse(new InputSource(in), xmlHandler);
+			}
+		} finally {
+			conn.disconnect();
+		}
+
 		List<ScopusArticle> scopusArticles = xmlHandler.getScopusArticles();
 		int errorCount = xmlHandler.getErrorEntryCount();
 		if (errorCount > 0) {
@@ -55,7 +99,7 @@ public class ScopusUriParserCallable implements Callable<List<ScopusArticle>> {
 				scopusArticles.size(), errorCount, uri);
 		return scopusArticles;
 	}
-	
+
 	@Override
 	public List<ScopusArticle> call() throws Exception {
 		return parse(uri);

--- a/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
+++ b/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
@@ -77,10 +77,12 @@ public class ScopusArticleRetriever {
 
 		List<RetryerCallable<List<ScopusArticle>>> callables = new ArrayList<>();
 		
+		// Retry only on a null result or a transient I/O error (timeouts, connection
+		// resets). Deterministic failures (e.g. a malformed response) are not retried —
+		// re-fetching the same URL would fail identically and just waste 10 attempts.
 		Retryer<List<ScopusArticle>> retryer = RetryerBuilder.<List<ScopusArticle>>newBuilder()
                 .retryIfResult(Predicates.<List<ScopusArticle>>isNull())
                 .retryIfExceptionOfType(IOException.class)
-                .retryIfRuntimeException()
                 .withWaitStrategy(WaitStrategies.fibonacciWait(100L, 2L, TimeUnit.MINUTES))
                 .withStopStrategy(StopStrategies.stopAfterAttempt(10))
                 .build();
@@ -114,6 +116,11 @@ public class ScopusArticleRetriever {
 			}).forEach(list::add);
 		} catch (InterruptedException e) {
 			slf4jLogger.error("Unable to invoke callable.", e);
+			Thread.currentThread().interrupt();
+		} finally {
+			// The pool is created per request; shut it down so its worker threads do not
+			// accumulate (a hung Scopus call would otherwise keep them alive indefinitely).
+			executor.shutdownNow();
 		}
 
 		List<ScopusArticle> results = new ArrayList<>();


### PR DESCRIPTION
## Summary

Closes the availability and security gaps on the Scopus retrieval path. Previously a raw `HttpURLConnection` had **no timeouts** and was never closed, the SAX factory was **XXE-open**, deterministic runtime failures were retried 10×, and the per-request thread pool was leaked.

## Changes

**`ScopusUriParserCallable`**
- Connect (15s) and read (120s) timeouts — a stalled `api.elsevier.com` socket now fails with `SocketTimeoutException` (retried as I/O) instead of pinning a worker thread forever.
- Response body read in try-with-resources; `disconnect()` in a `finally` — no more leaked sockets/streams on the exception path.
- Parse with a shared SAX factory hardened against XXE: `disallow-doctype-decl`, external general/parameter entities off, `FEATURE_SECURE_PROCESSING`, no XInclude. (Scopus responses contain no DOCTYPE, so blocking DTDs is safe.)

**`ScopusArticleRetriever`**
- Shut down the per-request `ExecutorService` in a `finally` so worker threads can't accumulate.
- Restore the interrupt flag on `InterruptedException`.
- Retry only on a null result or `IOException` — dropped the blanket `retryIfRuntimeException()` that re-fetched deterministically-failing batches all 10 times.

## Findings addressed

#3 (CRITICAL, no timeouts / leaked connection), #7 (HIGH, executor leak), #14 (MED, XXE), #15 (MED, blanket runtime retry).

## Testing

`mvn clean package` on JDK 11 → **BUILD SUCCESS, 7/7 tests**. The retrieval timeout/XXE behavior exercises the live Scopus path, which requires valid credentials (rotation pending) to verify end-to-end; unit tests cover the parser, not the network call.

## Note

A follow-up could fold these into a singleton `@Service` owning a shared bounded pool + pooled HTTP client (finding #16), which would subsume the per-request executor entirely. This PR is the minimal, non-structural fix that closes the availability/security gap.