### PR TITLE
Trim unused transitive dependencies from the fat jar; pin Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,19 @@
         <java.version>11</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- guava-retrying declares an open-ended Guava range "[10.+,)", which lets a
+                 clean build silently pull whatever the newest Guava is. Pin it for
+                 reproducible builds. -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.6.0-jre</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -42,6 +55,19 @@
         		<exclusion>
         			<groupId>org.slf4j</groupId>
         			<artifactId>slf4j-simple</artifactId>
+        		</exclusion>
+        		<!-- The model jar transitively drags ~30 unused jars into the fat jar: a
+        		     2016-era AWS SDK and a build-time Swagger codegen plugin (with maven-core,
+        		     aether, plexus, rhino, libphonenumber, swagger 1.5.19...). This service
+        		     calls neither at runtime, so exclude both to shrink the jar and remove
+        		     stale CVE surface. -->
+        		<exclusion>
+        			<groupId>com.amazonaws</groupId>
+        			<artifactId>aws-java-sdk-dynamodb</artifactId>
+        		</exclusion>
+        		<exclusion>
+        			<groupId>io.swagger</groupId>
+        			<artifactId>swagger-codegen-maven-plugin</artifactId>
         		</exclusion>
         	</exclusions>
         </dependency>


### PR DESCRIPTION
## Summary

`reciter-scopus-model:2.0.3` transitively drags ~30 unused jars into the runtime fat jar: a 2016-era AWS SDK (`aws-java-sdk-dynamodb` → s3/kms/core/jmespath/joda-time/httpclient) **and** a build-time Swagger codegen plugin (`swagger-codegen-maven-plugin` → maven-core, aether, plexus, rhino, libphonenumber, swagger 1.5.19, handlebars...). This service calls none of them at runtime.

`guava-retrying:2.0.0` also declares an open-ended Guava version range `[10.+,)`, so a clean build can silently resolve a different (newest) Guava each time.

## Changes

- Exclude `com.amazonaws:aws-java-sdk-dynamodb` and `io.swagger:swagger-codegen-maven-plugin` from the model dependency. (The `io.swagger.annotations.*` used by the controllers come from Springfox, not this chain, so the exclusion is safe.)
- Pin `com.google.guava:guava` to `33.6.0-jre` in `dependencyManagement`.

## Result

- Fat jar: **~44 MB → ~27 MB**.
- Dependency tree no longer contains `aws-java-sdk-*`, `swagger-codegen*`, `rhino`, `libphonenumber`, or `joda-time` — removing their stale CVE surface.
- Guava resolution is now reproducible.

## Findings addressed

#10 (HIGH, model drags AWS SDK + swagger-codegen plugin), #22 (MED, open-ended Guava range).

## Testing

`mvn clean package` on JDK 11 → **BUILD SUCCESS, 7/7 tests**; verified the excluded artifacts are absent from `mvn dependency:tree` and the controllers still compile against Springfox's swagger annotations.