### PR TITLE
Run unit tests in CI; add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      - name: Build and run unit tests
+        run: mvn -B -ntp clean verify

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,7 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - mvn clean install -Dmaven.test.skip=true
+      - mvn clean install
   post_build:
     commands:
       - echo Build completed on `date`

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -40,7 +40,7 @@ phases:
         - cat ./kubernetes/k8-deployment.yaml
   build:
     commands:
-      - mvn clean install -Dmaven.test.skip=true
+      - mvn clean install
       - |
         if expr "${BRANCH}" : ".*master" >/dev/null || expr "${BRANCH}" : ".*dev" >/dev/null; then
           docker build --tag $REPOSITORY_URI:$TAG .


### PR DESCRIPTION
## Summary

The `ScopusXmlHandler` test suite was never run by any pipeline: both CodeBuild buildspecs passed `-Dmaven.test.skip=true` (skipping test compilation *and* execution), and there was no GitHub Actions workflow. Parser regressions could ship undetected — exactly the kind of bug the recent `d359d17` fix and PR #11 address.

## Changes

- Remove `-Dmaven.test.skip=true` from `buildspec.yml` and `k8-buildspec.yml` so CodeBuild runs the unit tests. The suite is pure (`StringReader` input) and needs no credentials or network, so it is safe in the pipeline.
- Add `.github/workflows/ci.yml`: Temurin JDK 11 + `mvn -B -ntp clean verify` on every push and PR. `reciter-scopus-model:2.0.3` resolves from Maven Central, so no private-repo configuration is required.

## Findings addressed

#12 (HIGH, tests skipped in CI), #23 (MED, no GitHub Actions CI).

## Testing

`mvn -B -ntp clean verify` on JDK 11 → **BUILD SUCCESS, 7/7 tests** (the same command the new workflow runs).