### PR TITLE
Fix Kubernetes deploy: HPA apiVersion, namespace target, startup probe

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -15,10 +15,7 @@ phases:
         # Extract username and password from the JSON response
         - DOCKER_USERNAME=$(echo $SECRET | sed -n 's/.*"username":"\([^"]*\)".*/\1/p')
         - DOCKER_PASSWORD=$(echo $SECRET | sed -n 's/.*"password":"\([^"]*\)".*/\1/p')
-      
-        # Print the Docker username to the CodeBuild log
-        - echo "Docker Username $DOCKER_USERNAME"
-        
+
         # Log in to Docker registry
         - echo "Logging in to Docker registry"
         - echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
@@ -50,8 +47,8 @@ phases:
           aws eks update-kubeconfig --name $EKS_CLUSTER_NAME --region us-east-1 --role-arn $EKS_KUBECTL_ROLE_ARN
         fi
         if expr "${BRANCH}" : ".*master" >/dev/null; then
-          kubectl set image deployment/reciter-scopus-prod reciter-scopus=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME
+          kubectl set image deployment/reciter-scopus-prod reciter-scopus=$REPOSITORY_URI:$TAG -n reciter
         fi
         if expr "${BRANCH}" : ".*dev" >/dev/null; then
-          kubectl set image deployment/reciter-scopus-dev reciter-scopus=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME
+          kubectl set image deployment/reciter-scopus-dev reciter-scopus=$REPOSITORY_URI:$TAG -n reciter
         fi

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -58,6 +58,16 @@ spec:
           limits:
             memory: 1.5G
             cpu: 0.6
+        # Give the JVM time to cold-start (Boot 2.4 fat jar on 0.5 CPU, Ec2Spot)
+        # before liveness/readiness begin, so a slow start is not killed as a crash.
+        startupProbe:
+          httpGet:
+            path: "/scopus/ping"
+            port: 5000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 18
+          timeoutSeconds: 3
         livenessProbe:
           httpGet:
             path: "/scopus/ping"
@@ -112,7 +122,7 @@ spec:
           configMap:
             name: scopus-nginx-configmap
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: HPANAME


### PR DESCRIPTION
## Summary

Correctness fixes for the Kubernetes deploy path.

## Changes

- **HPA `autoscaling/v2beta2` → `autoscaling/v2`** (`k8-deployment.yaml`). `v2beta2` is removed in k8s 1.26+, where `kubectl apply` fails to create the HPA and the service stays pinned at `replicas: 1` (no scale-out). The metric schema is already v2-compatible, so this is a pure apiVersion bump.
- **`kubectl set image … -n reciter`** instead of `-n $EKS_CLUSTER_NAME` (`k8-buildspec.yml`). The deployment is created in namespace `reciter` (the `NAMESPACE` token is sed-substituted to `reciter` for both dev and prod), but the rollout used the *cluster-name* variable as the namespace. ⚠️ **Please verify against the live pipeline**: if the EKS cluster happens to be named `reciter` this is a no-op; otherwise the image update has been silently targeting the wrong namespace and pods never roll. The `aws eks update-kubeconfig --name $EKS_CLUSTER_NAME` usage is correct and untouched.
- **Add a `startupProbe`** to the app container (`failureThreshold: 18`, ~180s grace) so a slow Boot 2.4 cold start on 0.5 CPU / Ec2Spot isn't killed by the aggressive liveness probe.
- **Remove `echo "Docker Username $DOCKER_USERNAME"`** from the build log.

## Findings addressed

#11 (HIGH, namespace bug), #25 (MED, HPA apiVersion), #26 (MED, probe timing), #39 (LOW, username echo).

## Testing

Both YAML files validated (`yaml.safe_load_all`). No application code change. The namespace fix should be confirmed against the actual cluster name before relying on it.