### PR TITLE
Docker/local-dev hygiene: Corretto base, externalized compose secrets, nginx sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM amazoncorretto:11-alpine
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -8,4 +8,4 @@ COPY ${JAR_FILE} /app/app.jar
 RUN wget https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip && \
     unzip newrelic-java.zip -d /app
 EXPOSE 5000
-CMD java -Djava.security.egd=file:/dev/./urandom -XX:+PrintFlagsFinal $JAVA_OPTIONS -jar /app/app.jar
+CMD java -Djava.security.egd=file:/dev/./urandom $JAVA_OPTIONS -jar /app/app.jar

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,10 @@ services:
     restart: always
     build: ./
     working_dir: /app
-    environment: 
-      - SCOPUS_API_KEY=e0fa610418a4859d24f2457e021aea60
-      - SCOPUS_INST_TOKEN=d44a98333430d51ce0c860c2b84b9032
+    # Credentials are read from the shell environment / an untracked .env file.
+    # Never hardcode the Scopus API key or institutional token here.
+    environment:
+      - SCOPUS_API_KEY=${SCOPUS_API_KEY}
+      - SCOPUS_INST_TOKEN=${SCOPUS_INST_TOKEN}
     expose:
       - "5000"
-    command: mvn clean spring-boot:run

--- a/nginx/conf.d/nginx.conf
+++ b/nginx/conf.d/nginx.conf
@@ -3,7 +3,7 @@ server {
         listen [::]:80 default_server;
 
         location /scopus {
-            rewrite ^/scopus/swagger-ui.html$ /swagger-ui.html break;
+            rewrite ^/scopus/swagger-ui/index.html$ /swagger-ui/index.html break;
             rewrite ^/scopus/(.*)$ /scopus/$1 break;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary

Hygiene for the container image and local-dev compose setup.

## Changes

- **Dockerfile**
  - Replace the **EOL `adoptopenjdk/openjdk11:alpine-jre`** base with **`amazoncorretto:11-alpine`** — matches the CodeBuild `corretto11` runtime and the Java-17 migration branch's `amazoncorretto:17-alpine`. **Verified the image builds** locally (the NewRelic `wget` + `unzip` steps work on the Corretto Alpine base).
  - Drop `-XX:+PrintFlagsFinal`, which dumped the full JVM flag table to stdout on every boot.
- **docker-compose.yaml**
  - Stop hardcoding the Scopus API key / institutional token — read them from the shell env / an untracked `.env` via `${SCOPUS_API_KEY}` / `${SCOPUS_INST_TOKEN}`, matching the K8s `secretKeyRef`.
  - Remove the `command: mvn clean spring-boot:run` override, which could never run (the image is JRE-only with no Maven or source) and left the compose `app` service unstartable. It now uses the Dockerfile `CMD`.
- **nginx/conf.d/nginx.conf**: sync the Swagger-UI rewrite to the Springfox-3 path (`/swagger-ui/index.html`), matching `kubernetes/k8-configmap.yaml`; the bundled copy still pointed at the old Springfox-2 `/swagger-ui.html`.

## Findings addressed

#24 (MED, Dockerfile base/flags), #27 (MED, broken compose command + hardcoded secret), #37 (LOW, stale bundled nginx rewrite).

## ⚠️ Note on the secret

Externalizing the compose secret prevents **re-leaking** but does **not** remove the historical value from git history. The previously-committed key/token must still be **rotated** and the history scrubbed (tracked separately).

## Testing

`docker build` succeeds on the new base. `docker-compose.yaml` validated as YAML; verified no credential literals remain in the working tree. `mvn clean package` (JDK 11) builds the jar the image copies.