### PR TITLE
Remove dead code and stale config/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ReCiter-Scopus-Retrieval-Tool
 
 ![Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoid0xxSUlOU1ZkOW9QNkwyem5wbDJKQTNieEZHMXNCc3NXalJJRlVCR2c3KzJtWDByOWVOek54Ukh4TXVHcGhsYUFFajk2Y0tRNDVNUzF1SHJPVDhhaDM0PSIsIml2UGFyYW1ldGVyU3BlYyI6IjNCZEI0Q3RoN3hWME1uM3QiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
-![version](https://img.shields.io/badge/version-1.0-blue.svg?maxAge=2592000)
+![version](https://img.shields.io/badge/version-1.1.0-blue.svg?maxAge=2592000)
 [![codebeat badge](https://codebeat.co/badges/7a467876-39c4-4e2b-8987-0183f596ffd9)](https://codebeat.co/projects/github-com-wcmc-its-reciter-scopus-retrieval-tool-master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
@@ -31,7 +31,6 @@ This tool has several advantages over using the Scopus API alone:
 
 - Java 11
 - Latest version of Maven. To install Maven navigate to the directory where ReCiter Scopus Retrieval Tool will be installed, execute `brew install maven` and then `mvn clean install`
-If you want to use Java 8 then update `<java.version>1.8</java.version>` in [pom.xml](https://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool/blob/59b12e33edf744afe4431f3e4d35e5ba16821b09/pom.xml#L18)
 
 It is not necessary to install ReCiter in order to use the API.
 

--- a/src/main/java/reciter/scopus/querybuilder/ScopusXmlQuery.java
+++ b/src/main/java/reciter/scopus/querybuilder/ScopusXmlQuery.java
@@ -2,19 +2,11 @@ package reciter.scopus.querybuilder;
 
 public class ScopusXmlQuery {
 	
-	private final String query;
-	private final int count;
-	private final String field;
-	private final int start;
 	private final String queryUrl;
-	
+
 	private static final String SCOPUS_URL_PREFIX = "https://api.elsevier.com/content/search/scopus?query=";
-	
+
 	private ScopusXmlQuery(ScopusXmlQueryBuilder scopusXmlQueryBuilder) {
-		query = scopusXmlQueryBuilder.query;
-		count = scopusXmlQueryBuilder.count;
-		field = scopusXmlQueryBuilder.field;
-		start = scopusXmlQueryBuilder.start;
 		queryUrl = scopusXmlQueryBuilder.queryUrl;
 	}
 	
@@ -33,26 +25,9 @@ public class ScopusXmlQuery {
 		private int start = 0;
 		private String queryUrl;
 		
-		public ScopusXmlQueryBuilder(String query) {
-			this.query = query;
-			count = 1; // Assuming that it's fetching a single Scopus article.
-		}
-		
 		public ScopusXmlQueryBuilder(String query, int count) {
 			this.query = query;
 			this.count = count;
-		}
-		public ScopusXmlQueryBuilder count(int count) {
-			this.count = count;
-			return this;
-		}
-		public ScopusXmlQueryBuilder field(String field) {
-			this.field = field;
-			return this;
-		}
-		public ScopusXmlQueryBuilder start(int start) {
-			this.start = start;
-			return this;
 		}
 		public ScopusXmlQuery build() {
 			StringBuilder sb = new StringBuilder();
@@ -67,42 +42,6 @@ public class ScopusXmlQuery {
 			queryUrl = sb.toString();
 			return new ScopusXmlQuery(this);
 		}
-		
-		public ScopusXmlQuery buildSingle() {
-			StringBuilder sb = new StringBuilder();
-			sb.append(ScopusXmlQuery.SCOPUS_URL_PREFIX);
-			sb.append("pmid(");
-			sb.append(query);
-			sb.append(")");
-			sb.append("&count=");
-			sb.append(count);
-			sb.append("&field=");
-			sb.append(field);
-			sb.append("&start=");
-			sb.append(start);
-			queryUrl = sb.toString();
-			return new ScopusXmlQuery(this);
-		}
-	}
-
-	public String getQuery() {
-		return query;
-	}
-
-	public int getCount() {
-		return count;
-	}
-
-	public String getField() {
-		return field;
-	}
-
-	public int getStart() {
-		return start;
-	}
-
-	public static String getScopusUrlPrefix() {
-		return SCOPUS_URL_PREFIX;
 	}
 
 	public String getQueryUrl() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-logging.file=logs/reciter-scopus-retrieval-tool.log
 server.port=5000


### PR DESCRIPTION
## Summary

Low-risk cleanup of dead code, a dead config line, and doc drift.

## Changes

- **`ScopusXmlQuery`**: delete the unused single-arg (`count=1`) builder constructor, the `count()` / `field()` / `start()` setters, `buildSingle()` (which also hardcoded `pmid(`, ignoring the query type — a latent bug), and the unused getters. The live path only uses the `(query, count)` builder, `build()`, and `getQueryUrl()`. The class drops from 111 to 50 lines with no behavior change.
- **`application.properties`**: drop `logging.file=logs/...`. The bare `logging.file` key was removed in Spring Boot 2.4, so it is silently ignored and the app already logs to stdout (which CloudWatch collects on EKS). Removing it avoids a misleading "fix" to `logging.file.name` that would reintroduce in-container file logging.
- **`README.md`**: version badge `1.0` → `1.1.0` (matching `pom.xml`); drop the stale Java-8 downgrade instruction and its commit-pinned pom link.

## Findings addressed

#40 / #41 (LOW, dead code), #33 (LOW, deprecated logging key), #44 (LOW, README drift).

## Testing

`mvn -B -ntp clean verify` on JDK 11 → **BUILD SUCCESS, 7/7 tests**.