### PR TITLE
URL-encode Scopus identifiers; clean up query batching

### DIFF
--- a/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
+++ b/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
@@ -1,8 +1,9 @@
 package reciter.scopus.retriever;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,14 +29,10 @@ public class ScopusArticleRetriever {
 	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusArticleRetriever.class);
 
 	/**
-	 * Scopus retrieval threshold.
+	 * Maximum number of identifiers per Scopus request. Each identifier (PMID/DOI/Scopus-ID)
+	 * matches at most one article, so this also bounds the result count requested per batch.
 	 */
-	protected static final int SCOPUS_DEFAULT_THRESHOLD = 24;
-
-	/**
-	 * Scopus retrieval max threshold.
-	 */
-	protected static final int SCOPUS_MAX_THRESHOLD = 25;
+	protected static final int SCOPUS_BATCH_SIZE = 25;
 
 	/**
 	 * @param pmids scopus query could be DOI, scopusDocId, PMID
@@ -44,36 +41,7 @@ public class ScopusArticleRetriever {
 	 */
 	public List<ScopusArticle> retrieveScopus(List<Object> pmids, String type) {
 		slf4jLogger.info("Pmids:" + pmids);
-		List<String> pmidQueries = new ArrayList<>();
-		if (pmids.size() == 1) {
-			pmidQueries.add(type + "(" + pmids.get(0) + ")");
-		} else {
-			StringBuilder sb = new StringBuilder();
-			int i = 0;
-			Iterator<Object> itr = pmids.iterator();
-			while (itr.hasNext()) {
-				Object pmid = itr.next();
-				if (i == 0 || (i % SCOPUS_DEFAULT_THRESHOLD != 0 && i != pmids.size() - 1)) {
-					sb.append(type + "(");
-					sb.append(pmid);
-					sb.append(")+OR+");
-				} else {
-					sb.append(type + "(");
-					sb.append(pmid);
-					sb.append(")");
-				}
-				if (i != 0 && i % SCOPUS_DEFAULT_THRESHOLD == 0) {
-					pmidQueries.add(sb.toString());
-					sb = new StringBuilder();
-				}
-				i++;
-			}
-			// add the remaining pmids
-			String remaining = sb.toString();
-			if (!remaining.isEmpty()) {
-				pmidQueries.add(remaining);
-			}
-		}
+		List<String> pmidQueries = buildBatchQueries(pmids, type, SCOPUS_BATCH_SIZE);
 
 		List<RetryerCallable<List<ScopusArticle>>> callables = new ArrayList<>();
 		
@@ -88,7 +56,7 @@ public class ScopusArticleRetriever {
 		//List<Callable<List<ScopusArticle>>> callables = new ArrayList<>();
 
 		for (String query : pmidQueries) {
-			ScopusXmlQuery scopusXmlQuery = new ScopusXmlQuery.ScopusXmlQueryBuilder(query, SCOPUS_MAX_THRESHOLD).build();
+			ScopusXmlQuery scopusXmlQuery = new ScopusXmlQuery.ScopusXmlQueryBuilder(query, SCOPUS_BATCH_SIZE).build();
 			String scopusUrl = scopusXmlQuery.getQueryUrl();
 			ScopusUriParserCallable scopusUriParserCallable = new ScopusUriParserCallable(new ScopusXmlHandler(), scopusUrl);
 			RetryerCallable<List<ScopusArticle>> retryerCallable = retryer.wrap(scopusUriParserCallable);
@@ -119,5 +87,32 @@ public class ScopusArticleRetriever {
 		List<ScopusArticle> results = new ArrayList<>();
 		list.forEach(results::addAll);
 		return results;
+	}
+
+	/**
+	 * Splits the identifiers into batches of at most {@code batchSize} and builds one Scopus
+	 * OR-query per batch, e.g. {@code doi(10.1/x)+OR+doi(10.2/y)}. Each identifier value is
+	 * URL-encoded so a DOI containing reserved characters (&amp;, #, spaces, parentheses)
+	 * cannot break the request URL or inject extra query parameters. The forward slash present
+	 * in every DOI is kept literal, matching the long-standing working behavior.
+	 */
+	static List<String> buildBatchQueries(List<Object> identifiers, String type, int batchSize) {
+		List<String> queries = new ArrayList<>();
+		for (int start = 0; start < identifiers.size(); start += batchSize) {
+			int end = Math.min(start + batchSize, identifiers.size());
+			StringBuilder sb = new StringBuilder();
+			for (int i = start; i < end; i++) {
+				if (i > start) {
+					sb.append("+OR+");
+				}
+				sb.append(type).append('(').append(encodeIdentifier(identifiers.get(i))).append(')');
+			}
+			queries.add(sb.toString());
+		}
+		return queries;
+	}
+
+	static String encodeIdentifier(Object value) {
+		return URLEncoder.encode(String.valueOf(value), StandardCharsets.UTF_8).replace("%2F", "/");
 	}
 }

--- a/src/test/java/reciter/scopus/retriever/ScopusArticleRetrieverTest.java
+++ b/src/test/java/reciter/scopus/retriever/ScopusArticleRetrieverTest.java
@@ -1,0 +1,109 @@
+package reciter.scopus.retriever;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Scopus query construction in {@link ScopusArticleRetriever}:
+ * per-identifier URL-encoding (so DOIs with reserved characters cannot corrupt the
+ * request) and fixed-size OR-batching.
+ */
+class ScopusArticleRetrieverTest {
+
+    // ------------------------------------------------------------------
+    // Identifier encoding
+    // ------------------------------------------------------------------
+
+    @Test
+    void encodesReservedCharactersButKeepsSlash() {
+        // Slash is kept literal (every DOI has one and it has always worked);
+        // the URL-reserved characters that would break the request are encoded.
+        assertEquals("10.1002/%28SICI%29", ScopusArticleRetriever.encodeIdentifier("10.1002/(SICI)"));
+        assertEquals("a%26b", ScopusArticleRetriever.encodeIdentifier("a&b"));
+        assertEquals("frag%23x", ScopusArticleRetriever.encodeIdentifier("frag#x"));
+        assertEquals("a+b", ScopusArticleRetriever.encodeIdentifier("a b"));
+    }
+
+    @Test
+    void numericIdentifierUnchanged() {
+        assertEquals("20000000", ScopusArticleRetriever.encodeIdentifier("20000000"));
+        assertEquals("12345", ScopusArticleRetriever.encodeIdentifier(12345));
+    }
+
+    @Test
+    void doiQueryDoesNotContainRawReservedChars() {
+        // A DOI carrying & / space / # must not leak those into the query string raw,
+        // which would split the URL or start a fragment.
+        List<String> q = ScopusArticleRetriever.buildBatchQueries(
+                Collections.singletonList("10.1/a&b c#d"), "doi", 25);
+        assertEquals(1, q.size());
+        String query = q.get(0);
+        assertFalse(query.contains("&"), "raw & would start a new URL parameter");
+        assertFalse(query.contains(" "), "raw space would break the URL");
+        assertFalse(query.contains("#"), "raw # would start a URL fragment");
+        assertTrue(query.startsWith("doi(") && query.endsWith(")"));
+    }
+
+    // ------------------------------------------------------------------
+    // Batching
+    // ------------------------------------------------------------------
+
+    @Test
+    void emptyInputYieldsNoQueries() {
+        assertTrue(ScopusArticleRetriever.buildBatchQueries(new ArrayList<>(), "pmid", 25).isEmpty());
+    }
+
+    @Test
+    void singleIdentifier() {
+        assertEquals(Collections.singletonList("pmid(20000000)"),
+                ScopusArticleRetriever.buildBatchQueries(Collections.singletonList("20000000"), "pmid", 25));
+    }
+
+    @Test
+    void multipleIdentifiersJoinedWithOr() {
+        assertEquals(Collections.singletonList("pmid(1)+OR+pmid(2)+OR+pmid(3)"),
+                ScopusArticleRetriever.buildBatchQueries(Arrays.asList("1", "2", "3"), "pmid", 25));
+    }
+
+    @Test
+    void splitsIntoFixedSizeBatches() {
+        assertEquals(1, batchCount(25), "25 ids -> 1 batch");
+        assertEquals(2, batchCount(26), "26 ids -> 2 batches");
+        assertEquals(2, batchCount(50), "50 ids -> 2 batches");
+        assertEquals(3, batchCount(51), "51 ids -> 3 batches");
+
+        // Exactly one boundary-spanning case: 26 ids -> [25, 1]
+        List<String> q = ScopusArticleRetriever.buildBatchQueries(ids(26), "pmid", 25);
+        assertEquals(25, clauseCount(q.get(0)));
+        assertEquals(1, clauseCount(q.get(1)));
+    }
+
+    private static int batchCount(int n) {
+        return ScopusArticleRetriever.buildBatchQueries(ids(n), "pmid", 25).size();
+    }
+
+    private static List<Object> ids(int n) {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(String.valueOf(i));
+        }
+        return list;
+    }
+
+    private static int clauseCount(String query) {
+        // Each clause is one "pmid(" occurrence.
+        int count = 0;
+        int idx = 0;
+        while ((idx = query.indexOf("pmid(", idx)) != -1) {
+            count++;
+            idx += 5;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

The DOI-fallback path (ReCiter sends real DOIs via `type: "doi"`) concatenated identifier values straight into the Scopus request URL with **no encoding**. A DOI containing reserved characters breaks the request:
- `&` starts a new query parameter, clobbering `&count` / `&field` / `&start`;
- `#` truncates the rest as a URL fragment;
- a space breaks the URL entirely.

The result is silently wrong or empty Scopus results with no error.

## Changes

- **URL-encode each identifier** with `URLEncoder` before wrapping it in `TYPE(...)`. The forward slash present in every DOI is kept literal (it has always worked); the reserved characters that break the URL are now encoded.
- **Replace the modulo batching loop** — which produced a 25-item first batch then 24-item batches and only worked because `count == threshold + 1` — with straightforward fixed-size partitioning into batches of `SCOPUS_BATCH_SIZE` (25, matching the requested result count). Extracted into a testable static `buildBatchQueries(...)`.

## Findings addressed

#9 (HIGH, DOI not URL-encoded), #20 (MED, batching off-by-one).

## Consumer impact

Confirmed against `ReCiter/.../scopus/retriever/ScopusArticleRetriever.java`: ReCiter uses the DOI fallback in production, so this is a real fix, not theoretical. The merged result set is unchanged for well-formed identifiers; only the on-the-wire encoding/batching changes.

## Known limitation

This makes the request URL well-formed for all DOIs. DOIs containing parentheses (e.g. legacy SICI DOIs) still produce literal parens inside the Scopus query after URL-decoding — the same as today. Quoting those is a separate change best verified against the live Scopus API with a valid key.

## Testing

`mvn -B -ntp clean verify` on JDK 11 → **BUILD SUCCESS, 14/14 tests** (7 new construction/encoding tests + 7 existing).

## Note

Touches `ScopusArticleRetriever` (query construction) — disjoint from PR #12 (retry/executor changes in the same file); they merge cleanly.