### PR TITLE
Validate Scopus requests and return 400 instead of 500

### DIFF
--- a/src/main/java/reciter/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reciter/controller/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package reciter.controller;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Translates request-handling failures into clean JSON responses.
+ *
+ * <p>Validation failures ({@link IllegalArgumentException} from
+ * {@link ScopusController#validate}) and unreadable request bodies become HTTP 400 instead of
+ * a 500 with a stack trace. Genuinely unexpected errors are left to Spring Boot's default
+ * handler, which already returns a 500 without leaking the stack trace to the caller.</p>
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger slf4jLogger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler({IllegalArgumentException.class, HttpMessageNotReadableException.class})
+    public ResponseEntity<Map<String, Object>> handleBadRequest(Exception e) {
+        String message = (e instanceof HttpMessageNotReadableException)
+                ? "Request body is missing or not valid JSON."
+                : e.getMessage();
+        slf4jLogger.warn("Rejected Scopus request: {}", message);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
+        body.put("message", message);
+        return ResponseEntity.badRequest().body(body);
+    }
+}

--- a/src/main/java/reciter/controller/ScopusController.java
+++ b/src/main/java/reciter/controller/ScopusController.java
@@ -2,6 +2,9 @@ package reciter.controller;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +29,13 @@ import reciter.scopus.retriever.ScopusArticleRetriever;
 public class ScopusController {
     private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusController.class);
 
+    /** Identifier types this service understands (compared case-insensitively). */
+    static final Set<String> ALLOWED_TYPES = Set.of("pmid", "doi", "scopus-id", "af-id");
+
     @ApiOperation(value = "Querying Scopus with PMID, SCOPUS-ID or DOI. Add type it only accepts PMID,SCOPUS-ID or DOI(case-insensitive)", response = List.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully retrieved list"),
+            @ApiResponse(code = 400, message = "The request body is missing required fields or has an unsupported type"),
             @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
             @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
             @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
@@ -36,10 +43,29 @@ public class ScopusController {
     @PostMapping(value = "/query/", produces = "application/json")
     @ResponseBody
     public ResponseEntity<List<ScopusArticle>> retrieve(@RequestBody ScopusQuery scopusQuery) {
-        slf4jLogger.info("calling retrieve with pmids size=[" + scopusQuery.getQuery().size() + "]");
+        validate(scopusQuery);
+        int size = scopusQuery.getQuery().size();
+        slf4jLogger.info("calling retrieve with pmids size=[" + size + "]");
         ScopusArticleRetriever scopusArticleRetriever = new ScopusArticleRetriever();
         List<ScopusArticle> scopusArticles = scopusArticleRetriever.retrieveScopus(new ArrayList<>(scopusQuery.getQuery()), scopusQuery.getType());
-        slf4jLogger.info("finished retrieving with pmids size=[" + scopusQuery.getQuery().size() + "]");
+        slf4jLogger.info("finished retrieving with pmids size=[" + size + "]");
         return ResponseEntity.ok(scopusArticles);
+    }
+
+    /**
+     * Rejects malformed requests with an {@link IllegalArgumentException} (mapped to HTTP 400
+     * by {@link GlobalExceptionHandler}) instead of letting a null {@code query} NPE into a 500
+     * or an unsupported {@code type} get concatenated raw into the Scopus query.
+     */
+    static void validate(ScopusQuery scopusQuery) {
+        if (scopusQuery == null || scopusQuery.getQuery() == null || scopusQuery.getQuery().isEmpty()) {
+            throw new IllegalArgumentException("'query' must be a non-empty list of identifiers.");
+        }
+        String type = scopusQuery.getType();
+        if (type == null || !ALLOWED_TYPES.contains(type.trim().toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("'type' must be one of "
+                    + ALLOWED_TYPES.stream().sorted().collect(Collectors.toList())
+                    + " (case-insensitive).");
+        }
     }
 }

--- a/src/test/java/reciter/controller/ScopusControllerValidationTest.java
+++ b/src/test/java/reciter/controller/ScopusControllerValidationTest.java
@@ -1,0 +1,65 @@
+package reciter.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.model.scopus.ScopusQuery;
+
+/**
+ * Unit tests for {@link ScopusController#validate} — the request guard that turns malformed
+ * input into a 400 instead of an NPE/500 or a raw type concatenated into the Scopus query.
+ */
+class ScopusControllerValidationTest {
+
+    private static ScopusQuery query(List<Object> query, String type) {
+        return new ScopusQuery(query, type);
+    }
+
+    @Test
+    void acceptsSupportedTypesCaseInsensitively() {
+        assertDoesNotThrow(() -> {
+            ScopusController.validate(query(Collections.singletonList("123"), "pmid"));
+            ScopusController.validate(query(Collections.singletonList("123"), "PMID"));
+            ScopusController.validate(query(Collections.singletonList("10.1/x"), "doi"));
+            ScopusController.validate(query(Collections.singletonList("10.1/x"), "DOI"));
+            ScopusController.validate(query(Collections.singletonList("85"), "scopus-id"));
+            ScopusController.validate(query(Collections.singletonList("60"), "AF-ID"));
+        });
+    }
+
+    @Test
+    void rejectsNullBody() {
+        assertThrows(IllegalArgumentException.class, () -> ScopusController.validate(null));
+    }
+
+    @Test
+    void rejectsNullQuery() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScopusController.validate(query(null, "pmid")));
+    }
+
+    @Test
+    void rejectsEmptyQuery() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScopusController.validate(query(Collections.emptyList(), "pmid")));
+    }
+
+    @Test
+    void rejectsNullType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScopusController.validate(query(Collections.singletonList("123"), null)));
+    }
+
+    @Test
+    void rejectsUnsupportedType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScopusController.validate(query(Collections.singletonList("123"), "eid")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ScopusController.validate(query(Collections.singletonList("123"), "")));
+    }
+}

--- a/src/test/java/reciter/controller/ScopusControllerWebTest.java
+++ b/src/test/java/reciter/controller/ScopusControllerWebTest.java
@@ -1,0 +1,54 @@
+package reciter.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import reciter.Application;
+
+/**
+ * Verifies that malformed requests are answered with HTTP 400 (via
+ * {@link GlobalExceptionHandler}) rather than a 500. The 400 paths fail in {@code validate}
+ * before any Scopus call is made, so no credentials or network are needed.
+ *
+ * <p>Uses an explicit {@code classes = Application.class} because the app bootstraps with
+ * {@code @EnableAutoConfiguration} + {@code @ComponentScan} rather than
+ * {@code @SpringBootApplication}, so Spring's default config search finds nothing.</p>
+ */
+@SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ScopusControllerWebTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void unsupportedTypeReturns400() throws Exception {
+        mockMvc.perform(post("/scopus/query/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"query\":[\"123\"],\"type\":\"eid\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void emptyQueryReturns400() throws Exception {
+        mockMvc.perform(post("/scopus/query/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"query\":[],\"type\":\"pmid\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void malformedJsonReturns400() throws Exception {
+        mockMvc.perform(post("/scopus/query/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{not json"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary

The controller dereferenced `scopusQuery.getQuery()` with no guard (a missing `query` NPE'd into a **500**) and concatenated `type` straight into the Scopus query with no validation.

## Changes

- **Validate** the request: reject a null/empty `query` and an unsupported `type` (allowlist: `pmid`, `doi`, `scopus-id`, `af-id`, case-insensitive) with `IllegalArgumentException`.
- **Add `GlobalExceptionHandler`** (`@RestControllerAdvice`) mapping `IllegalArgumentException` and unreadable request bodies to a clean **400** JSON response (`{status, error, message}`). Genuinely unexpected errors are left to Spring Boot's default 500 handler, which already hides the stack trace — so the advice doesn't clobber framework status codes.

## Findings addressed

#18 (MED, type not validated/allowlisted), #34 (LOW, unvalidated body → NPE/500), #43 (LOW, no global exception handler).

## Consumer impact

Confirmed against the ReCiter client: it only ever sends `type` `"pmid"`/`"doi"` with a non-empty `query` (it returns early on empty input). So production traffic is unaffected — this only hardens the contract for malformed or direct API callers.

## Testing

`mvn -B -ntp clean verify` on JDK 11 → **BUILD SUCCESS, 16/16 tests**: `validate()` unit tests (6) + MockMvc tests (3) asserting 400 for unsupported type, empty query, and malformed JSON, plus the existing parser suite.

## Note

Touches only `ScopusController` + a new advice class — disjoint from all other open PRs.