### PR TITLE
Document that af-id queries return at most 25 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,9 @@ Ths Scopus Retrieval Tool API only allows you to search one field at a time. Fie
   "type": "af-id"
 }
 ```
+
+> **Note:** `pmid`, `doi`, and `scopus-id` lookups each match a single article, but an
+> `af-id` query can match an entire institution's output. This service requests only the
+> first 25 results per query and does **not** paginate, so an `af-id` search returns at most
+> 25 articles. It is intended for identifier lookups; bulk affiliation harvesting is out of
+> scope.


### PR DESCRIPTION
## Summary

Adds a README note that an `af-id` (institutional affiliation) query returns **at most 25 articles** and does not paginate, unlike the single-article `pmid`/`doi`/`scopus-id` lookups.

Per the agreed approach for finding #19: ReCiter never sends `af-id` in production, so rather than build pagination machinery for an unused path, we document the cap so direct API users following the README's `af-id` example aren't surprised.

## Findings addressed

#19 (MED → documented): AF-ID queries silently capped at 25.

## Testing

Docs-only change. No code touched.