### PR TITLE
Group C: re-cut Boot 3.4.3 / Java 17 / springdoc migration onto hardened dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 11
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
 
       - name: Build and run unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11-alpine
+FROM amazoncorretto:17-alpine
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar reciter-scopus-retrieval-tool-1.1.0.jar
+web: java -jar reciter-scopus-retrieval-tool-3.0.0.jar

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ReCiter-Scopus-Retrieval-Tool
 
 ![Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoid0xxSUlOU1ZkOW9QNkwyem5wbDJKQTNieEZHMXNCc3NXalJJRlVCR2c3KzJtWDByOWVOek54Ukh4TXVHcGhsYUFFajk2Y0tRNDVNUzF1SHJPVDhhaDM0PSIsIml2UGFyYW1ldGVyU3BlYyI6IjNCZEI0Q3RoN3hWME1uM3QiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
-![version](https://img.shields.io/badge/version-1.1.0-blue.svg?maxAge=2592000)
+![version](https://img.shields.io/badge/version-3.0.0-blue.svg?maxAge=2592000)
 [![codebeat badge](https://codebeat.co/badges/7a467876-39c4-4e2b-8987-0183f596ffd9)](https://codebeat.co/projects/github-com-wcmc-its-reciter-scopus-retrieval-tool-master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
@@ -29,7 +29,7 @@ This tool has several advantages over using the Scopus API alone:
 
 ## Prerequisites
 
-- Java 11
+- Java 17
 - Latest version of Maven. To install Maven navigate to the directory where ReCiter Scopus Retrieval Tool will be installed, execute `brew install maven` and then `mvn clean install`
 
 It is not necessary to install ReCiter in order to use the API.

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto17
     commands:
       - echo Nothing to do in the install phase...
   pre_build:
@@ -16,9 +16,9 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-      - cp target/reciter-scopus-retrieval-tool-1.1.0.jar .
+      - cp target/reciter-scopus-retrieval-tool-3.0.0.jar .
 artifacts:
   files:
-    - reciter-scopus-retrieval-tool-1.1.0.jar
+    - reciter-scopus-retrieval-tool-3.0.0.jar
     - .ebextensions/**/* 
     - Procfile

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
     commands:
       - kubectl version --short --client   
   pre_build:

--- a/pom.xml
+++ b/pom.xml
@@ -1,89 +1,84 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>edu.wcmc.reciter</groupId>
-  <artifactId>reciter-scopus-retrieval-tool</artifactId>
-  <version>1.1.0</version>
-  <name>ReCiter-Scopus-Retrieval-Tool</name>
-  <description>A tool to retrieve Scopus articles.</description>
-  <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
-        <relativePath />
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>edu.wcmc.reciter</groupId>
+	<artifactId>reciter-scopus-retrieval-tool</artifactId>
+	<version>3.0.0</version>
+	<name>ReCiter-Scopus-Retrieval-Tool</name>
+	<description>A tool to retrieve Scopus articles.</description>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.3</version>
+		<relativePath />
+	</parent>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
-    </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>17</java.version>
+		<corretto.version>17</corretto.version>
+	</properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- guava-retrying declares an open-ended Guava range "[10.+,)", which lets a
-                 clean build silently pull whatever the newest Guava is. Pin it for
-                 reproducible builds. -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<dependencyManagement>
+		<dependencies>
+			<!-- guava-retrying declares an open-ended Guava range "[10.+,)", which lets a
+			     clean build silently pull whatever the newest Guava is. Pin it for
+			     reproducible builds. -->
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>33.6.0-jre</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-        <dependency>
-        	<groupId>edu.cornell.weill.reciter</groupId>
-        	<artifactId>reciter-scopus-model</artifactId>
-        	<version>2.0.3</version>
-        	<exclusions>
-        		<exclusion>
-        			<groupId>org.slf4j</groupId>
-        			<artifactId>slf4j-simple</artifactId>
-        		</exclusion>
-        		<!-- The model jar transitively drags ~30 unused jars into the fat jar: a
-        		     2016-era AWS SDK and a build-time Swagger codegen plugin (with maven-core,
-        		     aether, plexus, rhino, libphonenumber, swagger 1.5.19...). This service
-        		     calls neither at runtime, so exclude both to shrink the jar and remove
-        		     stale CVE surface. -->
-        		<exclusion>
-        			<groupId>com.amazonaws</groupId>
-        			<artifactId>aws-java-sdk-dynamodb</artifactId>
-        		</exclusion>
-        		<exclusion>
-        			<groupId>io.swagger</groupId>
-        			<artifactId>swagger-codegen-maven-plugin</artifactId>
-        		</exclusion>
-        	</exclusions>
-        </dependency>
-        <dependency>
-      		<groupId>com.github.rholder</groupId>
-      		<artifactId>guava-retrying</artifactId>
-      		<version>2.0.0</version>
-    	</dependency>
-    </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>edu.cornell.weill.reciter</groupId>
+			<artifactId>reciter-scopus-model</artifactId>
+			<version>3.0.0</version>
+			<!-- model 3.0.0 is a self-contained POJO jar with no transitive dependencies
+			     (verified via dependency:tree). Unlike 2.0.3 it no longer drags the 2016-era
+			     AWS SDK, the swagger-codegen plugin, or slf4j-simple, so the exclusions the
+			     2.0.3 dependency needed (PR #13) are unnecessary here. -->
+		</dependency>
+		<dependency>
+			<groupId>com.github.rholder</groupId>
+			<artifactId>guava-retrying</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/reciter/OpenApiConfig.java
+++ b/src/main/java/reciter/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package reciter;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    servers = {
+        // Setting the server URL to the root context path forces the browser to resolve
+        // the full URL using the current page's scheme (HTTPS), so springdoc "Try it out"
+        // works behind the nginx/ALB TLS terminator instead of emitting an http:// URL.
+        @Server(url = "/", description = "Relative context path (Forces HTTPS)")
+    }
+)
+public class OpenApiConfig {}

--- a/src/main/java/reciter/controller/PingController.java
+++ b/src/main/java/reciter/controller/PingController.java
@@ -1,22 +1,20 @@
 package reciter.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
 @RequestMapping("/scopus")
-@Api(value = "PingController", tags = {"Health Check"})
+@Tag(name = "PingController", description = "Health Check")
 public class PingController {
 
-    @ApiOperation(value = "Health check", response = ResponseEntity.class)
+	@Operation(summary = "Health check", description = "Returns the health status of the application")
     @GetMapping(value = "/ping", produces = "text/plain")
-    @ResponseBody
     public ResponseEntity<String> ping() {
         return ResponseEntity.ok("Healthy");
     }

--- a/src/main/java/reciter/controller/ScopusController.java
+++ b/src/main/java/reciter/controller/ScopusController.java
@@ -9,23 +9,22 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import reciter.model.scopus.ScopusArticle;
 import reciter.model.scopus.ScopusQuery;
 import reciter.scopus.retriever.ScopusArticleRetriever;
 
-@Controller
+@RestController
 @RequestMapping("/scopus")
-@Api(value="ScopusController", tags = {"Querying Scopus with PMID, SCOPUS-ID or DOI"})
+@Tag(name = "ScopusController", description = "Querying Scopus with PMID, SCOPUS-ID or DOI")
 public class ScopusController {
     private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusController.class);
 
@@ -38,16 +37,15 @@ public class ScopusController {
         this.scopusArticleRetriever = scopusArticleRetriever;
     }
 
-    @ApiOperation(value = "Querying Scopus with PMID, SCOPUS-ID or DOI. Add type it only accepts PMID,SCOPUS-ID or DOI(case-insensitive)", response = List.class)
+    @Operation(summary = "Querying Scopus with PMID, SCOPUS-ID or DOI. Add type it only accepts PMID,SCOPUS-ID or DOI(case-insensitive)")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list"),
-            @ApiResponse(code = 400, message = "The request body is missing required fields or has an unsupported type"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "400", description = "The request body is missing required fields or has an unsupported type"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @PostMapping(value = "/query/", produces = "application/json")
-    @ResponseBody
     public ResponseEntity<List<ScopusArticle>> retrieve(@RequestBody ScopusQuery scopusQuery) {
         validate(scopusQuery);
         int size = scopusQuery.getQuery().size();

--- a/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
+++ b/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;

--- a/src/main/java/reciter/swagger/SwaggerConfig.java
+++ b/src/main/java/reciter/swagger/SwaggerConfig.java
@@ -1,38 +1,29 @@
 package reciter.swagger;
 
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import static springfox.documentation.builders.PathSelectors.regex;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
-    @Bean
-    public Docket productApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("reciter.controller"))
-                .paths(regex("/scopus.*"))
-                .build()
-                .apiInfo(apiInfo());
-    }
 
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("ReCiter publication management system - Scopus Retrieval Tool")
-                .description("Retrieve publications from Scopus. More info here: http://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool/").termsOfServiceUrl("")
-                .contact(new Contact("Paul J. Albert", "https://github.com/wcmc-its/ReCiter", "paa2013@med.cornell.edu"))
-                .license("Apache License Version 2.0")
-                .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0")
-                .version("1.1.0")
-                .build();
-    }
+	@Bean
+	public GroupedOpenApi productApi() {
+		return GroupedOpenApi.builder().group("reciter-group").packagesToScan("reciter.controller")
+				.pathsToMatch("/scopus/**").build();
+	}
+
+	@Bean
+	public OpenAPI apiInfo() {
+		return new OpenAPI().info(new Info().title("ReCiter publication management system - Scopus Retrieval Tool")
+				.version("3.0.0")
+				.contact(new Contact().name("Paul J. Albert").url("https://github.com/wcmc-its/ReCiter")
+						.email("paa2013@med.cornell.edu"))
+				.description(
+						"Retrieve publications from Scopus. More info here: http://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool/"));
+	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 server.port=5000
+server.forward-headers-strategy=FRAMEWORK
+springdoc.api-docs.path=/scopus/v3/api-docs


### PR DESCRIPTION
## What

Re-cuts the Boot 3.4.3 / Java 17 / springdoc migration (previously on `MigrationFromJDk11ToAWSCorretto17`) on top of the Group A+B hardening now on `dev`, instead of merging that branch as-is.

**Why re-cut instead of merging the migration branch:** the migration branch was cut before the A+B hardening and carried none of it (no parser fix, no `@Service`/timeouts/XXE, no DOI encoding, no request validation, no CI-runs-tests, no `-n reciter` namespace fix, dead `logging.file`). Merging it as-is would have regressed every A+B fix. This branch instead applies only the cutover-specific changes on the already-hardened base; the two are largely orthogonal — the migration touches config + the controller Swagger annotations, while A+B rewrote the parser/retriever/callable the migration never touched.

Targets `dev`. **Does not touch `master`/prod** — promotion via `dev → master` triggers the prod CodePipeline and is the owner's call.

## Changes

- **pom**: Spring Boot 3.4.3 parent, Java 17, `springdoc-openapi-starter-webmvc-ui` 2.8.5, `reciter-scopus-model` 3.0.0, validation starter; keeps the Guava 33.6.0-jre pin. model 3.0.0 is a lean leaf jar (verified via `dependency:tree`), so the AWS-SDK / swagger-codegen / slf4j-simple exclusions the 2.0.3 dependency needed are dropped.
- **Controllers**: `io.swagger.v3` (springdoc) annotations + `@RestController`. `ScopusController` keeps the request validation + constructor injection of the `@Service` retriever, plus a 400 `@ApiResponse`.
- **springdoc config**: `SwaggerConfig` (GroupedOpenApi) + new `OpenApiConfig` (relative `/` server so Swagger UI resolves HTTPS behind the proxy); `application.properties` adds `forward-headers-strategy=FRAMEWORK` and `springdoc.api-docs.path=/scopus/v3/api-docs`, drops dead `logging.file`.
- **jakarta**: `javax.annotation.PreDestroy` → `jakarta.annotation.PreDestroy` (the `javax.xml` JAXP imports stay — JDK classes).
- **Docker / CI / deploy**: `amazoncorretto:17-alpine` (no PrintFlagsFinal); buildspecs run on `corretto17` and keep the A+B fixes (tests run, `-n reciter`); EB artifact + Procfile bumped to 3.0.0; CI on JDK 17.

## Verification

- `mvn clean verify` green on **JDK 17 / Boot 3.4.3** — 32 tests, 0 failures (parser, retriever, validation, and a `@SpringBootTest` web test that boots the full Boot 3 context).
- `dependency:tree`: model 3.0.0 has no transitive deps; Boot manages Jackson 2.18.2 (no pin needed/added); Guava pinned 33.6.0-jre; model jar bytecode is jakarta-clean.
- 4-agent adversarial review: A+B hardening confirmed fully intact; swagger-ui traced as reachable behind the `/scopus` nginx prefix. Review fixes applied: Procfile + README version drift (1.1.0 → 3.0.0, Java 11 → 17).

## Outstanding (gated — not done here)

- **Live Scopus end-to-end** (timeouts / XXE / DOI-encoding / partial-results / `@Service` against the real API) — needs rotated API key + inst token; run on `dev` once creds are rotated.
- **springdoc behind nginx/ALB** — config is coherent but relies on springfox-era nginx rules left unchanged; confirm `/scopus/swagger-ui/index.html` + `/scopus/v3/api-docs` return 200 on the dev cluster (the PubMed #120 gotcha). nginx/configmap intentionally untouched.
- **Unused `spring-boot-starter-validation`** carried from the migration (validation is manual) — candidate to drop or wire `@Valid`.
- **Prod promotion** (`dev → master`) is the owner's call.

Built on the post-A+B `dev` (A+B PRs #11, #13–#21 already merged).
