### PR TITLE
feat(search): authenticated Scopus search proxy (documents + authors)

### DIFF
--- a/src/main/java/reciter/controller/ScopusSearchController.java
+++ b/src/main/java/reciter/controller/ScopusSearchController.java
@@ -1,0 +1,100 @@
+package reciter.controller;
+
+import java.net.http.HttpResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reciter.scopus.search.ScopusSearchService;
+
+/**
+ * Scopus <em>search</em> endpoints (distinct from the id → article retrieval on
+ * {@link ScopusController}). Both proxy Elsevier with the tool's credentials and return
+ * the Elsevier {@code search-results} JSON verbatim, so the caller keeps its own parsing.
+ *
+ *   GET /scopus/search/documents?by={author|keyword|doi}&term=...
+ *   GET /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ */
+@RestController
+@RequestMapping("/scopus/search")
+public class ScopusSearchController {
+
+	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusSearchController.class);
+
+	private final ScopusSearchService searchService;
+
+	public ScopusSearchController(ScopusSearchService searchService) {
+		this.searchService = searchService;
+	}
+
+	@GetMapping(value = "/documents", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> documents(
+			@RequestParam(name = "by", required = false) String by,
+			@RequestParam(name = "term") String term) {
+		if (isBlank(term)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"term is required\"}");
+		}
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchDocuments(by, term));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	@GetMapping(value = "/authors", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> authors(
+			@RequestParam(name = "lastName") String lastName,
+			@RequestParam(name = "firstName", required = false) String firstName,
+			@RequestParam(name = "affiliation", required = false) String affiliation) {
+		if (isBlank(lastName)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"lastName is required\"}");
+		}
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchAuthors(lastName, firstName, affiliation));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	// Pass Elsevier's status and JSON body straight through to the caller.
+	private ResponseEntity<String> passthrough(HttpResponse<String> resp) {
+		return ResponseEntity.status(resp.statusCode())
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(resp.body());
+	}
+
+	private ResponseEntity<String> credentialsMissing() {
+		return ResponseEntity.status(503)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("{\"error\":\"Scopus credentials are not configured on this server.\"}");
+	}
+
+	private ResponseEntity<String> upstreamFailure(Exception e) {
+		slf4jLogger.error("Scopus search failed", e);
+		return ResponseEntity.status(502)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("{\"error\":\"Scopus search failed\"}");
+	}
+
+	private static boolean isBlank(String s) {
+		return s == null || s.trim().isEmpty();
+	}
+}

--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -1,0 +1,119 @@
+package reciter.scopus.search;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Authenticated proxy for Elsevier's Scopus <em>search</em> APIs (document search and
+ * author search), which the article-retrieval path ({@link reciter.scopus.retriever.ScopusArticleRetriever})
+ * does not cover. The Publication Manager used to call Elsevier directly and therefore
+ * needed its own API key; routing through here keeps the Elsevier credentials in one place.
+ *
+ * <p>This is a thin proxy: it builds the Scopus query, calls Elsevier with the tool's
+ * credentials, and returns the Elsevier search JSON verbatim (status and body passed
+ * through). The caller parses {@code search-results} as before.
+ */
+@Service
+public class ScopusSearchService {
+
+	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusSearchService.class);
+
+	private static final String SCOPUS_SEARCH = "https://api.elsevier.com/content/search/scopus";
+	private static final String AUTHOR_SEARCH = "https://api.elsevier.com/content/search/author";
+
+	/** Scopus returns at most this many documents per request; the JSON's total reports the real count. */
+	private static final int DOCUMENT_PAGE_SIZE = 200;
+	private static final int AUTHOR_PAGE_SIZE = 10;
+	private static final String DEFAULT_AFFILIATION = "Weill Cornell";
+
+	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(60);
+
+	// Same credentials the retrieval path uses (injected into the deployment as env/secret).
+	private static final String INST_TOKEN = System.getenv("SCOPUS_INST_TOKEN");
+	private static final String API_KEY = System.getenv("SCOPUS_API_KEY");
+
+	private final HttpClient httpClient;
+
+	public ScopusSearchService() {
+		this.httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+		if (API_KEY == null || INST_TOKEN == null) {
+			slf4jLogger.warn("SCOPUS_API_KEY and/or SCOPUS_INST_TOKEN are not set; "
+					+ "Scopus search requests will be rejected until they are configured.");
+		}
+	}
+
+	/** True once both Elsevier credentials are present; the controller returns 503 otherwise. */
+	public boolean isConfigured() {
+		return API_KEY != null && INST_TOKEN != null;
+	}
+
+	/**
+	 * Search Scopus documents. {@code by} selects the query field:
+	 * {@code keyword} → TITLE-ABS-KEY (relevance order), {@code doi} → DOI, anything else
+	 * → AU-ID (author id, newest first). Returns Elsevier's {@code search-results} JSON.
+	 */
+	public HttpResponse<String> searchDocuments(String by, String term)
+			throws IOException, InterruptedException {
+		String t = term == null ? "" : term.trim();
+		String query;
+		String sort = "&sort=-coverDate";
+		if ("keyword".equals(by)) {
+			query = "TITLE-ABS-KEY(" + t + ")";
+			sort = ""; // relevance order
+		} else if ("doi".equals(by)) {
+			query = "DOI(" + t + ")";
+		} else {
+			query = "AU-ID(" + t.replaceFirst("(?i)^AUTHOR_ID:", "") + ")";
+		}
+		String url = SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort;
+		return get(url);
+	}
+
+	/**
+	 * Search Scopus authors by name, scoped to an affiliation (defaults to Weill Cornell).
+	 * Returns Elsevier's {@code search-results} JSON of author profiles.
+	 */
+	public HttpResponse<String> searchAuthors(String lastName, String firstName, String affiliation)
+			throws IOException, InterruptedException {
+		StringBuilder q = new StringBuilder("authlast(").append(nullToEmpty(lastName).trim()).append(")");
+		String first = nullToEmpty(firstName).trim();
+		if (!first.isEmpty()) {
+			q.append(" AND authfirst(").append(first).append(")");
+		}
+		String affil = nullToEmpty(affiliation).trim();
+		q.append(" AND affil(").append(affil.isEmpty() ? DEFAULT_AFFILIATION : affil).append(")");
+		String url = AUTHOR_SEARCH + "?query=" + enc(q.toString()) + "&count=" + AUTHOR_PAGE_SIZE;
+		return get(url);
+	}
+
+	private HttpResponse<String> get(String url) throws IOException, InterruptedException {
+		slf4jLogger.info("Scopus search: {}", url);
+		HttpRequest.Builder builder = HttpRequest.newBuilder()
+				.uri(URI.create(url))
+				.timeout(REQUEST_TIMEOUT)
+				.header("Accept", "application/json")
+				.GET();
+		builder.header("X-ELS-Insttoken", INST_TOKEN);
+		builder.header("X-ELS-APIKey", API_KEY);
+		return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+	}
+
+	private static String enc(String s) {
+		return URLEncoder.encode(s, StandardCharsets.UTF_8);
+	}
+
+	private static String nullToEmpty(String s) {
+		return s == null ? "" : s;
+	}
+}


### PR DESCRIPTION
Adds authenticated Scopus **search** endpoints to the tool, so the Publication Manager can stop calling `api.elsevier.com` directly with its own API key.

Today the tool only retrieves articles by identifier (`POST /scopus/query/`). PM's Scopus Authorships tab needs document search (by author id, keyword, or DOI) and author search, and had been proxying Elsevier itself — which meant PM also had to hold `SCOPUS_API_KEY` / `SCOPUS_INST_TOKEN`.

## What this adds
- `GET /scopus/search/documents?by={author|keyword|doi}&term=…` — builds `AU-ID(…)` / `TITLE-ABS-KEY(…)` / `DOI(…)`, `count=200`, newest-first (relevance for keyword).
- `GET /scopus/search/authors?lastName=…&firstName=…&affiliation=…` — builds `authlast() AND authfirst() AND affil()` (affiliation defaults to *Weill Cornell*), `count=10`.

Both call Elsevier with the tool's existing `SCOPUS_API_KEY` / `SCOPUS_INST_TOKEN` and return the Elsevier `search-results` JSON **verbatim** (status + body passed through). The caller keeps its own parsing.

## Design
Thin proxy by intent: no new dependencies, no `pom.xml` change, no new model classes, no Swagger annotations (kept version-agnostic so it compiles on both the current Java 11 / Boot 2 `dev` and the incoming Java 17 / Boot 3 migration in #29 — the two new files are additive and do not touch anything #29 changes). Uses the same `java.net.http.HttpClient` idiom as the refactored `ScopusArticleRetriever`. Missing credentials → 503; blank `term`/`lastName` → 400; upstream errors passed through (or 502 on transport failure).

## Verification
Built (`mvn -DskipTests compile`, clean) and ran locally against **live Elsevier** with real credentials:
- keyword `CRISPR gene editing` → 200 entries, `opensearch:totalResults` 36441
- authors `Schuster, Michael` → 1 profile with `dc:identifier`, `preferred-name`, `document-count` 91, `affiliation-current` all present
- doi `10.1038/nature12373` → total 1, `pubmed-id` 23903748
- author-id (strips `AUTHOR_ID:` prefix) → 91 documents, matching the author's `document-count`
- missing `term` → 400; `/scopus/ping` → 200

Confirmed the passthrough JSON carries exactly the keys PM's parser reads (`dc:identifier`, `pubmed-id`, `prism:*`, `preferred-name`, `document-count`, `affiliation-current`, `opensearch:totalResults`).

Companion PM PR retargets `scopusSearch.controller.ts` at these endpoints and drops PM's Elsevier credentials.
