### PR TITLE
fix(deploy): apply the k8 manifest on dev so the startupProbe deploys (fixes scopus-dev crashloop)

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -55,7 +55,11 @@ phases:
           kubectl set image deployment/reciter-scopus-prod reciter-scopus=$REPOSITORY_URI:$TAG -n reciter
         fi
         if expr "${BRANCH}" : ".*dev" >/dev/null; then
-          kubectl set image deployment/reciter-scopus-dev reciter-scopus=$REPOSITORY_URI:$TAG -n reciter
+          # Apply the rendered manifest (CONTAINER_IMAGE already substituted above) rather than
+          # only bumping the image tag, so deployment changes — probes, env, resources — actually
+          # deploy. `set image` alone left the startupProbe in kubernetes/k8-deployment.yaml
+          # unapplied, so the slower Boot 3 image was killed by the liveness probe mid-startup.
+          kubectl apply -f kubernetes/k8-deployment.yaml -n reciter
         fi
         if expr "${BRANCH}" : ".*MigrationFromJDk11ToAWSCorretto17" >/dev/null; then
           kubectl set image deployment/reciter-scopus-prod reciter-scopus=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME


### PR DESCRIPTION
Fixes the `reciter-scopus-dev` CrashLoopBackOff introduced by the Boot 3 / Java 17 migration (#29).

## Root cause
The dev deploy step renders `kubernetes/k8-deployment.yaml` (substitutes the image tag + env) and `cat`s it, but then only runs `kubectl set image` — it **never `kubectl apply`s the manifest**. So every manifest change is inert; only the image tag on the existing live Deployment is updated.

A `startupProbe` was added to the manifest in `bf229a8` precisely for slow starts, but because the manifest is never applied, the **live** Deployment still has no `startupProbe` and a liveness probe with `initialDelaySeconds: 10`, `periodSeconds: 10`, `failureThreshold: 3`. The Boot 2 image booted fast enough to pass; the Boot 3 / Java 17 image (with the NewRelic + OpenTelemetry agents) takes ~42s to become ready:

```
Started Application in 20.399 seconds (process running for 42.72)
[ionShutdownHook] Commencing graceful shutdown
```

Liveness exhausts its 3 failures (~30s) and SIGTERMs the container (exit 143) just as it finishes starting → 53 restarts, "exceeded progress deadline". The 7-day-old Boot 2 pod keeps serving, so the rollout is stuck rather than fully down.

## Fix
Apply the rendered manifest on the dev arm instead of only bumping the image, so probes/env/resources deploy with the image. One line, plus a comment.

## Verification
- `k8-buildspec.yml` parses as valid YAML.
- Server-side dry-run of the rendered dev manifest: `deployment.apps/reciter-scopus-dev configured` + `horizontalpodautoscaler … configured` — confirming the live Deployment currently differs from git (missing the `startupProbe`) and that the manifest applies cleanly.

## Note
`master` (prod) has the same latent `set image`-only pattern; it works today only because the Boot 2 image starts fast. Recommend the same change there once the Boot 3 migration reaches prod. Left out of this PR to keep the prod deploy path untouched.

## After merge
This branch is based on top of the #31 merge, so a dev build from it produces an image **with the new `/scopus/search/*` endpoints** and applies the `startupProbe`. Trigger a `reciter-scopus-dev` build, confirm the pod goes Ready and `/scopus/search/documents` responds, then set `RECITER_SCOPUS_API_URL` on `reciter-pm-dev` and merge PM #797.
