### PR TITLE
fix(deploy): drop the dead lifecycle=Ec2Spot nodeSelector (keeps scopus-dev schedulable)

### DIFF
--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -115,8 +115,9 @@ spec:
         volumeMounts:
           - name:  nginx-conf
             mountPath:  /etc/nginx/conf.d
-      nodeSelector:
-        lifecycle: Ec2Spot
+      # No nodeSelector: the old `lifecycle: Ec2Spot` label no longer exists on any node
+      # in this cluster, so pinning to it left the pod Unschedulable. Let the scheduler
+      # place it on available capacity, as the running deployment already did.
       volumes:
         - name: nginx-conf  
           configMap:


### PR DESCRIPTION
Follow-up to #32. Removes the stale `nodeSelector: lifecycle=Ec2Spot` from the deployment manifest.

## Why
#32 made the dev pipeline `kubectl apply` the manifest (so the `startupProbe` finally deploys). That exposed a second stale field: `nodeSelector: lifecycle=Ec2Spot`. No node in the cluster carries that label anymore — the `reciter-spot-al2023-ng` nodegroup now runs `capacityType=ON_DEMAND`, and there is no `lifecycle` label anywhere. While `set image` was the only deploy step the live Deployment never had this selector, so it scheduled fine; once the manifest is genuinely applied, the pod pins to a selector nothing satisfies and stays **Unschedulable** (`0/13 nodes … didn't match Pod's node affinity/selector`).

## Fix
Drop the `nodeSelector`. The running deployment had none, so the scheduler places the pod on available capacity — which is what it already did.

## Verification
- `k8-deployment.yaml` parses as valid YAML; `startupProbe` retained.
- I already applied the equivalent change to the live `reciter-scopus-dev` Deployment (removed the nodeSelector). The new `dev-57` pod then scheduled and has been **2/2 Running, 0 restarts** under the `startupProbe`. This PR makes git match that live state so the next pipeline apply doesn't re-pin to the dead label.
