### PR TITLE
feat(search): pass a Scopus query through verbatim, so a real strategy can run

### DIFF
--- a/src/main/java/reciter/controller/ScopusSearchController.java
+++ b/src/main/java/reciter/controller/ScopusSearchController.java
@@ -7,10 +7,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import reciter.scopus.search.ScopusSearchRequest;
 import reciter.scopus.search.ScopusSearchService;
 
 /**
@@ -18,8 +21,9 @@ import reciter.scopus.search.ScopusSearchService;
  * {@link ScopusController}). Both proxy Elsevier with the tool's credentials and return
  * the Elsevier {@code search-results} JSON verbatim, so the caller keeps its own parsing.
  *
- *   GET /scopus/search/documents?by={author|keyword|doi}&term=...
- *   GET /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ *   GET  /scopus/search/documents?by={author|keyword|doi}&term=...
+ *   GET  /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ *   POST /scopus/search/query    {query, count, start, view}   — query passed through VERBATIM
  */
 @RestController
 @RequestMapping("/scopus/search")
@@ -71,6 +75,80 @@ public class ScopusSearchController {
 			return upstreamFailure(e);
 		} catch (Exception e) {
 			return upstreamFailure(e);
+		}
+	}
+
+	/**
+	 * Run a search strategy: the query goes to Elsevier <strong>verbatim</strong>, and {@code count},
+	 * {@code start} and {@code view} are the caller's to set.
+	 *
+	 * <p>{@code /documents} cannot do this. It force-wraps every term in {@code TITLE-ABS-KEY(...)},
+	 * which makes a top-level limit ({@code AND PUBYEAR > 2020}) impossible to express — nested
+	 * inside the wrap, Elsevier rejects it outright. That wrap is right for a keyword lookup and
+	 * fatal for a peer-reviewable strategy, so this is a second endpoint rather than a flag on the
+	 * first: the two have genuinely different contracts for what {@code query} means.
+	 *
+	 * <p>POST, not GET, because a real strategy is thousands of characters once URL-encoded.
+	 */
+	@PostMapping(value = "/query",
+			consumes = MediaType.APPLICATION_JSON_VALUE,
+			produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> query(@RequestBody ScopusSearchRequest request) {
+		validate(request);                       // IllegalArgumentException -> 400 (GlobalExceptionHandler)
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchRaw(
+					request.query(), request.countOrDefault(), request.startOrDefault(), request.view()));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	/**
+	 * The guard, and it exists to FAIL LOUDLY rather than to be helpful.
+	 *
+	 * <p>Every rule here is one that Elsevier would otherwise answer with a silently wrong page
+	 * instead of an error, or with an error the caller could not act on:
+	 *
+	 * <ul>
+	 *   <li><b>count &gt; the view's ceiling</b> is rejected here rather than CLAMPED. Clamping is
+	 *       the tempting move — but a caller who asked for 50 COMPLETE records and got 25 without
+	 *       being told would render "top 50" over half a page. Elsevier itself answers a bare 400
+	 *       {@code INVALID_INPUT}; this at least says which knob to turn.</li>
+	 *   <li><b>count = 0</b> is rejected because Elsevier IGNORES it and returns 25 records. A
+	 *       caller who wants only the total asks for {@code count=1} and reads
+	 *       {@code opensearch:totalResults}.</li>
+	 * </ul>
+	 */
+	static void validate(ScopusSearchRequest r) {
+		if (r == null || isBlank(r.query())) {
+			throw new IllegalArgumentException("query is required");
+		}
+		String view = r.view() == null ? "" : r.view().trim();
+		if (!view.isEmpty() && !view.equalsIgnoreCase("STANDARD") && !view.equalsIgnoreCase("COMPLETE")) {
+			throw new IllegalArgumentException("view must be STANDARD or COMPLETE");
+		}
+		if (r.count() != null) {
+			int max = ScopusSearchService.maxCountFor(view);
+			if (r.count() < 1) {
+				throw new IllegalArgumentException(
+						"count must be at least 1; Scopus ignores count=0 and silently returns 25 records. "
+								+ "For a count without records, use count=1 and read opensearch:totalResults.");
+			}
+			if (r.count() > max) {
+				throw new IllegalArgumentException("count must be at most " + max
+						+ (r.isCompleteView()
+								? " when view=COMPLETE; page through the rest with start."
+								: "; page through the rest with start."));
+			}
+		}
+		if (r.start() != null && r.start() < 0) {
+			throw new IllegalArgumentException("start must be zero or greater");
 		}
 	}
 

--- a/src/main/java/reciter/scopus/search/ScopusSearchRequest.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchRequest.java
@@ -1,0 +1,43 @@
+package reciter.scopus.search;
+
+/**
+ * A Scopus search whose query is sent to Elsevier <strong>verbatim</strong>.
+ *
+ * <p>It is a POST body rather than a query string because a real search strategy is long — a
+ * peer-reviewable Boolean query runs to thousands of characters once URL-encoded, which is an
+ * uncomfortable place to be against a servlet's header limit. The PubMed retrieval tool takes its
+ * complex query the same way, for the same reason.
+ *
+ * @param query the Scopus query, EXACTLY as Elsevier will see it: field codes, Booleans, top-level
+ *              limits ({@code AND PUBYEAR > 2020}, {@code AND DOCTYPE(ar)}) and all. Nothing here
+ *              wraps, rewrites or translates it — see {@link ScopusSearchService#searchRaw}.
+ * @param count records per page. Optional; {@link #DEFAULT_COUNT} if absent. Bounded by the view —
+ *              see {@link ScopusSearchService#maxCountFor}.
+ * @param start zero-based offset of the first record. Optional; 0 if absent. This is how a caller
+ *              gets more records than a single COMPLETE page allows.
+ * @param view  {@code STANDARD} (default at Elsevier) or {@code COMPLETE} (abstracts and the full
+ *              author list — entitled for our institution token, verified against the live API).
+ */
+public record ScopusSearchRequest(String query, Integer count, Integer start, String view) {
+
+	/**
+	 * Safe in EITHER view, which is why it is the default: a COMPLETE page cannot exceed 25.
+	 *
+	 * <p>It is emphatically not 0. Elsevier IGNORES {@code count=0} and silently returns 25
+	 * records — so a caller who wanted "just the total, no records" and asked for zero would be
+	 * billed for a page and handed one, with nothing in the response to say so.
+	 */
+	public static final int DEFAULT_COUNT = 25;
+
+	public boolean isCompleteView() {
+		return view != null && "COMPLETE".equalsIgnoreCase(view.trim());
+	}
+
+	public int countOrDefault() {
+		return count == null ? DEFAULT_COUNT : count;
+	}
+
+	public int startOrDefault() {
+		return start == null ? 0 : start;
+	}
+}

--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -88,6 +88,54 @@ public class ScopusSearchService {
 	}
 
 	/**
+	 * Elsevier's page-size ceilings, which differ BY VIEW. Probed against the live API rather than
+	 * read off a page: with {@code view=COMPLETE}, {@code count=50} and {@code count=200} both come
+	 * back <strong>HTTP 400 INVALID_INPUT</strong> — not a truncated page, a refusal. So a caller
+	 * who wants more than 25 COMPLETE records must PAGE with {@code start}; there is no single call
+	 * that will do it, and pretending otherwise is how you end up printing "top 50" over 25 records.
+	 */
+	public static final int MAX_COUNT_COMPLETE = 25;
+	public static final int MAX_COUNT_STANDARD = 200;
+
+	/** The ceiling that applies to a given view. */
+	public static int maxCountFor(String view) {
+		return view != null && "COMPLETE".equalsIgnoreCase(view.trim()) ? MAX_COUNT_COMPLETE : MAX_COUNT_STANDARD;
+	}
+
+	/**
+	 * Search Scopus with the query passed through <strong>VERBATIM</strong>.
+	 *
+	 * <p>This is the whole point of this method, and the difference between it and
+	 * {@link #searchDocuments}: that one force-wraps the caller's terms in
+	 * {@code TITLE-ABS-KEY(...)}, so a caller can never express a TOP-LEVEL limit. Nest
+	 * {@code PUBYEAR > 2020} inside {@code TITLE-ABS-KEY()} and Elsevier answers
+	 * {@code HTTP 400 "Error translating query"} — loudly, which is the good news, but it means the
+	 * wrapped endpoint simply cannot run a real search strategy. Verified against the live API:
+	 * passed raw, a query narrows exactly as a librarian expects
+	 * (2,900 → {@code AND PUBYEAR > 2020} → 1,958 → {@code AND DOCTYPE(ar)} → 1,376).
+	 *
+	 * <p>The caller writes native Scopus. NOTHING here translates a query from another database's
+	 * syntax, and nothing ever should: Cochrane and PRESS expect a bespoke, separately peer-reviewed
+	 * strategy per database, and a mechanical MeSH → Scopus transliteration is exactly the artifact
+	 * a librarian would reject at review.
+	 *
+	 * <p>To COUNT without retrieving, ask for {@code count=1} and read
+	 * {@code search-results.opensearch:totalResults}. Not {@code count=0} — Elsevier ignores that
+	 * and silently returns 25 records.
+	 */
+	public HttpResponse<String> searchRaw(String query, int count, int start, String view)
+			throws IOException, InterruptedException {
+		StringBuilder url = new StringBuilder(SCOPUS_SEARCH)
+				.append("?query=").append(enc(query.trim()))
+				.append("&count=").append(count)
+				.append("&start=").append(start);
+		if (!nullToEmpty(view).trim().isEmpty()) {
+			url.append("&view=").append(enc(view.trim().toUpperCase()));
+		}
+		return get(url.toString());
+	}
+
+	/**
 	 * Search Scopus authors by name, scoped to an affiliation (defaults to Weill Cornell).
 	 * Returns Elsevier's {@code search-results} JSON of author profiles.
 	 */

--- a/src/test/java/reciter/controller/ScopusSearchQueryValidationTest.java
+++ b/src/test/java/reciter/controller/ScopusSearchQueryValidationTest.java
@@ -1,0 +1,93 @@
+package reciter.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.scopus.search.ScopusSearchRequest;
+import reciter.scopus.search.ScopusSearchService;
+
+/**
+ * Unit tests for {@link ScopusSearchController#validate} — the guard on the verbatim-query
+ * endpoint.
+ *
+ * <p>Every rule pinned here is one where Elsevier's own behaviour would otherwise hand the caller a
+ * confidently WRONG answer rather than an error, so a regression would be invisible:
+ *
+ * <ul>
+ *   <li>{@code count=0} is IGNORED by Elsevier, which returns 25 records — so "just give me the
+ *       total" must be {@code count=1}, and a zero has to be refused rather than passed on.</li>
+ *   <li>{@code view=COMPLETE} caps a page at 25. Both of these were probed against the live API:
+ *       {@code count=50&view=COMPLETE} is an HTTP 400, not a short page.</li>
+ * </ul>
+ */
+class ScopusSearchQueryValidationTest {
+
+	private static ScopusSearchRequest req(String query, Integer count, Integer start, String view) {
+		return new ScopusSearchRequest(query, count, start, view);
+	}
+
+	private static String messageOf(ScopusSearchRequest r) {
+		return assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(r)).getMessage();
+	}
+
+	@Test
+	void acceptsAStrategyWithTopLevelLimits() {
+		// The whole reason this endpoint exists: a top-level limit that TITLE-ABS-KEY() cannot hold.
+		assertDoesNotThrow(() -> ScopusSearchController.validate(
+				req("TITLE-ABS-KEY(probiotics AND depression) AND PUBYEAR > 2020 AND DOCTYPE(ar)", null, null, null)));
+	}
+
+	@Test
+	void rejectsMissingQuery() {
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(null));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req(null, null, null, null)));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("   ", null, null, null)));
+	}
+
+	/** count=0 is not "no records" — Elsevier ignores it and sends 25. Refuse it, and say so. */
+	@Test
+	void rejectsZeroCountAndSaysWhatToUseInstead() {
+		String msg = messageOf(req("probiotics", 0, null, null));
+		assertTrue(msg.contains("count=1"), "the error must point at the cheap-count idiom, got: " + msg);
+	}
+
+	/** The COMPLETE ceiling is 25, and a caller asking for 50 must be TOLD, not quietly given 25. */
+	@Test
+	void rejectsOversizedCompletePageRatherThanClampingIt() {
+		String msg = messageOf(req("probiotics", 50, null, "COMPLETE"));
+		assertTrue(msg.contains("25"), "the error must name the COMPLETE ceiling, got: " + msg);
+		assertTrue(msg.contains("start"), "the error must say how to get the rest, got: " + msg);
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 25, null, "COMPLETE")));
+		// 50 records at COMPLETE is two pages, and both of them are legal.
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 25, 25, "COMPLETE")));
+	}
+
+	/** STANDARD is a different ceiling, so the same count is fine there. */
+	@Test
+	void standardViewAllowsTwoHundred() {
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 200, null, null)));
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 200, null, "STANDARD")));
+		assertTrue(messageOf(req("probiotics", 201, null, "STANDARD")).contains("200"));
+		assertEquals(200, ScopusSearchService.maxCountFor(null));
+		assertEquals(200, ScopusSearchService.maxCountFor("STANDARD"));
+		assertEquals(25, ScopusSearchService.maxCountFor("complete"));   // case-insensitive, like Elsevier
+	}
+
+	@Test
+	void rejectsUnknownViewAndNegativeStart() {
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("x", null, null, "FULL")));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("x", null, -1, null)));
+	}
+
+	/** The default page has to be legal in EITHER view, or an unset count breaks COMPLETE. */
+	@Test
+	void defaultCountIsSafeInBothViews() {
+		assertEquals(25, req("x", null, null, null).countOrDefault());
+		assertEquals(0, req("x", null, null, null).startOrDefault());
+		assertTrue(ScopusSearchRequest.DEFAULT_COUNT <= ScopusSearchService.MAX_COUNT_COMPLETE);
+	}
+}


### PR DESCRIPTION
## Why

`/scopus/search/documents` **cannot run a search strategy**, and the reason is one line: `ScopusSearchService` force-wraps every term in `TITLE-ABS-KEY(...)`. That is right for a keyword lookup and fatal for a peer-reviewable strategy, because a **top-level limit cannot be expressed through it** — nest `PUBYEAR > 2020` inside `TITLE-ABS-KEY()` and Elsevier answers `HTTP 400 "Error translating query"`.

This is what the Publication Manager's Literature Search needs in order to offer Scopus at all.

## What

`POST /scopus/search/query` → `{query, count, start, view}`, Elsevier's JSON passed back verbatim.

A second endpoint rather than a flag on the first, because the two genuinely disagree about what `query` means. The query goes to Elsevier **exactly as the caller wrote it** — nothing wraps, rewrites or translates it, and nothing here ever should: Cochrane and PRESS expect a bespoke, separately peer-reviewed strategy per database, so the caller writes native Scopus. **There is no query-translation layer here and there must never be one.**

## The guard fails loudly, deliberately

Both rules are Elsevier behaviours that would otherwise hand a caller a *confidently wrong answer* rather than an error:

| Rule | Why it is not just pedantry |
|---|---|
| `count=0` rejected | Elsevier **ignores** it and silently returns **25 records**. So "just the total" is `count=1` + `opensearch:totalResults`, and the error message says exactly that. |
| `count > 25` rejected when `view=COMPLETE` | COMPLETE **caps a page at 25** — `count=50` is an `HTTP 400 INVALID_INPUT`, not a short page. We **reject rather than clamp**: a caller who asked for 50, got 25, and was not told would render "top 50" over half a page. More than 25 means paging with `start`, and the error says so. |

## Verified against the live Elsevier API, through the running jar

| Request | Result |
|---|---|
| `count=1` | total **2,900**, 1 record — the cheap count works |
| `+ AND PUBYEAR > 2020` (top-level limit) | total **1,958** |
| `+ AND DOCTYPE(ar)` (top-level limit) | total **942** |
| `view=COMPLETE count=25 start=0` / `start=25` | 25 + 25 records, **with abstracts and full author lists** |
| `count=50 & view=COMPLETE` / `count=0` / blank query | **400**, **400**, **400** |

`view=COMPLETE` being entitled on our institution token was the blocking unknown for Scopus in Literature Search. It is now proven **through this endpoint**, not just against a raw curl.

**39 tests, 0 failures** (7 new, covering the guard).

## Note for whoever ships this to prod

This lands on `dev`. **Prod builds from `master`**, and `master` has neither `ScopusSearchController` nor `ScopusSearchService` — it is Spring Boot 2.4.5 / Java 11 / v1.1.0, and `dev` is 61 commits ahead (and 5 behind). Getting this to prod is a **Boot 3 + Java 17 migration**, not a one-endpoint merge. Nothing in RPM needs that yet — Literature Search is a dev-only pilot — but it should be planned rather than discovered.