### PR TITLE
Add the Scopus search endpoints to the prod branch

### DIFF
--- a/src/main/java/reciter/controller/ScopusSearchController.java
+++ b/src/main/java/reciter/controller/ScopusSearchController.java
@@ -1,0 +1,100 @@
+package reciter.controller;
+
+import java.net.http.HttpResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reciter.scopus.search.ScopusSearchService;
+
+/**
+ * Scopus <em>search</em> endpoints (distinct from the id → article retrieval on
+ * {@link ScopusController}). Both proxy Elsevier with the tool's credentials and return
+ * the Elsevier {@code search-results} JSON verbatim, so the caller keeps its own parsing.
+ *
+ *   GET /scopus/search/documents?by={author|keyword|doi}&term=...
+ *   GET /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ */
+@RestController
+@RequestMapping("/scopus/search")
+public class ScopusSearchController {
+
+	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusSearchController.class);
+
+	private final ScopusSearchService searchService;
+
+	public ScopusSearchController(ScopusSearchService searchService) {
+		this.searchService = searchService;
+	}
+
+	@GetMapping(value = "/documents", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> documents(
+			@RequestParam(name = "by", required = false) String by,
+			@RequestParam(name = "term") String term) {
+		if (isBlank(term)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"term is required\"}");
+		}
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchDocuments(by, term));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	@GetMapping(value = "/authors", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> authors(
+			@RequestParam(name = "lastName") String lastName,
+			@RequestParam(name = "firstName", required = false) String firstName,
+			@RequestParam(name = "affiliation", required = false) String affiliation) {
+		if (isBlank(lastName)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"lastName is required\"}");
+		}
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchAuthors(lastName, firstName, affiliation));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	// Pass Elsevier's status and JSON body straight through to the caller.
+	private ResponseEntity<String> passthrough(HttpResponse<String> resp) {
+		return ResponseEntity.status(resp.statusCode())
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(resp.body());
+	}
+
+	private ResponseEntity<String> credentialsMissing() {
+		return ResponseEntity.status(503)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("{\"error\":\"Scopus credentials are not configured on this server.\"}");
+	}
+
+	private ResponseEntity<String> upstreamFailure(Exception e) {
+		slf4jLogger.error("Scopus search failed", e);
+		return ResponseEntity.status(502)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("{\"error\":\"Scopus search failed\"}");
+	}
+
+	private static boolean isBlank(String s) {
+		return s == null || s.trim().isEmpty();
+	}
+}

--- a/src/main/java/reciter/controller/ScopusSearchController.java
+++ b/src/main/java/reciter/controller/ScopusSearchController.java
@@ -7,10 +7,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import reciter.scopus.search.ScopusSearchRequest;
 import reciter.scopus.search.ScopusSearchService;
 
 /**
@@ -18,8 +21,9 @@ import reciter.scopus.search.ScopusSearchService;
  * {@link ScopusController}). Both proxy Elsevier with the tool's credentials and return
  * the Elsevier {@code search-results} JSON verbatim, so the caller keeps its own parsing.
  *
- *   GET /scopus/search/documents?by={author|keyword|doi}&term=...
- *   GET /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ *   GET  /scopus/search/documents?by={author|keyword|doi}&term=...
+ *   GET  /scopus/search/authors?lastName=...&firstName=...&affiliation=...
+ *   POST /scopus/search/query    {query, count, start, view}   — query passed through VERBATIM
  */
 @RestController
 @RequestMapping("/scopus/search")
@@ -71,6 +75,80 @@ public class ScopusSearchController {
 			return upstreamFailure(e);
 		} catch (Exception e) {
 			return upstreamFailure(e);
+		}
+	}
+
+	/**
+	 * Run a search strategy: the query goes to Elsevier <strong>verbatim</strong>, and {@code count},
+	 * {@code start} and {@code view} are the caller's to set.
+	 *
+	 * <p>{@code /documents} cannot do this. It force-wraps every term in {@code TITLE-ABS-KEY(...)},
+	 * which makes a top-level limit ({@code AND PUBYEAR > 2020}) impossible to express — nested
+	 * inside the wrap, Elsevier rejects it outright. That wrap is right for a keyword lookup and
+	 * fatal for a peer-reviewable strategy, so this is a second endpoint rather than a flag on the
+	 * first: the two have genuinely different contracts for what {@code query} means.
+	 *
+	 * <p>POST, not GET, because a real strategy is thousands of characters once URL-encoded.
+	 */
+	@PostMapping(value = "/query",
+			consumes = MediaType.APPLICATION_JSON_VALUE,
+			produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> query(@RequestBody ScopusSearchRequest request) {
+		validate(request);                       // IllegalArgumentException -> 400 (GlobalExceptionHandler)
+		if (!searchService.isConfigured()) {
+			return credentialsMissing();
+		}
+		try {
+			return passthrough(searchService.searchRaw(
+					request.query(), request.countOrDefault(), request.startOrDefault(), request.view()));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return upstreamFailure(e);
+		} catch (Exception e) {
+			return upstreamFailure(e);
+		}
+	}
+
+	/**
+	 * The guard, and it exists to FAIL LOUDLY rather than to be helpful.
+	 *
+	 * <p>Every rule here is one that Elsevier would otherwise answer with a silently wrong page
+	 * instead of an error, or with an error the caller could not act on:
+	 *
+	 * <ul>
+	 *   <li><b>count &gt; the view's ceiling</b> is rejected here rather than CLAMPED. Clamping is
+	 *       the tempting move — but a caller who asked for 50 COMPLETE records and got 25 without
+	 *       being told would render "top 50" over half a page. Elsevier itself answers a bare 400
+	 *       {@code INVALID_INPUT}; this at least says which knob to turn.</li>
+	 *   <li><b>count = 0</b> is rejected because Elsevier IGNORES it and returns 25 records. A
+	 *       caller who wants only the total asks for {@code count=1} and reads
+	 *       {@code opensearch:totalResults}.</li>
+	 * </ul>
+	 */
+	static void validate(ScopusSearchRequest r) {
+		if (r == null || isBlank(r.query())) {
+			throw new IllegalArgumentException("query is required");
+		}
+		String view = r.view() == null ? "" : r.view().trim();
+		if (!view.isEmpty() && !view.equalsIgnoreCase("STANDARD") && !view.equalsIgnoreCase("COMPLETE")) {
+			throw new IllegalArgumentException("view must be STANDARD or COMPLETE");
+		}
+		if (r.count() != null) {
+			int max = ScopusSearchService.maxCountFor(view);
+			if (r.count() < 1) {
+				throw new IllegalArgumentException(
+						"count must be at least 1; Scopus ignores count=0 and silently returns 25 records. "
+								+ "For a count without records, use count=1 and read opensearch:totalResults.");
+			}
+			if (r.count() > max) {
+				throw new IllegalArgumentException("count must be at most " + max
+						+ (r.isCompleteView()
+								? " when view=COMPLETE; page through the rest with start."
+								: "; page through the rest with start."));
+			}
+		}
+		if (r.start() != null && r.start() < 0) {
+			throw new IllegalArgumentException("start must be zero or greater");
 		}
 	}
 

--- a/src/main/java/reciter/scopus/search/ScopusSearchRequest.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchRequest.java
@@ -1,0 +1,43 @@
+package reciter.scopus.search;
+
+/**
+ * A Scopus search whose query is sent to Elsevier <strong>verbatim</strong>.
+ *
+ * <p>It is a POST body rather than a query string because a real search strategy is long — a
+ * peer-reviewable Boolean query runs to thousands of characters once URL-encoded, which is an
+ * uncomfortable place to be against a servlet's header limit. The PubMed retrieval tool takes its
+ * complex query the same way, for the same reason.
+ *
+ * @param query the Scopus query, EXACTLY as Elsevier will see it: field codes, Booleans, top-level
+ *              limits ({@code AND PUBYEAR > 2020}, {@code AND DOCTYPE(ar)}) and all. Nothing here
+ *              wraps, rewrites or translates it — see {@link ScopusSearchService#searchRaw}.
+ * @param count records per page. Optional; {@link #DEFAULT_COUNT} if absent. Bounded by the view —
+ *              see {@link ScopusSearchService#maxCountFor}.
+ * @param start zero-based offset of the first record. Optional; 0 if absent. This is how a caller
+ *              gets more records than a single COMPLETE page allows.
+ * @param view  {@code STANDARD} (default at Elsevier) or {@code COMPLETE} (abstracts and the full
+ *              author list — entitled for our institution token, verified against the live API).
+ */
+public record ScopusSearchRequest(String query, Integer count, Integer start, String view) {
+
+	/**
+	 * Safe in EITHER view, which is why it is the default: a COMPLETE page cannot exceed 25.
+	 *
+	 * <p>It is emphatically not 0. Elsevier IGNORES {@code count=0} and silently returns 25
+	 * records — so a caller who wanted "just the total, no records" and asked for zero would be
+	 * billed for a page and handed one, with nothing in the response to say so.
+	 */
+	public static final int DEFAULT_COUNT = 25;
+
+	public boolean isCompleteView() {
+		return view != null && "COMPLETE".equalsIgnoreCase(view.trim());
+	}
+
+	public int countOrDefault() {
+		return count == null ? DEFAULT_COUNT : count;
+	}
+
+	public int startOrDefault() {
+		return start == null ? 0 : start;
+	}
+}

--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -1,0 +1,119 @@
+package reciter.scopus.search;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Authenticated proxy for Elsevier's Scopus <em>search</em> APIs (document search and
+ * author search), which the article-retrieval path ({@link reciter.scopus.retriever.ScopusArticleRetriever})
+ * does not cover. The Publication Manager used to call Elsevier directly and therefore
+ * needed its own API key; routing through here keeps the Elsevier credentials in one place.
+ *
+ * <p>This is a thin proxy: it builds the Scopus query, calls Elsevier with the tool's
+ * credentials, and returns the Elsevier search JSON verbatim (status and body passed
+ * through). The caller parses {@code search-results} as before.
+ */
+@Service
+public class ScopusSearchService {
+
+	private static final Logger slf4jLogger = LoggerFactory.getLogger(ScopusSearchService.class);
+
+	private static final String SCOPUS_SEARCH = "https://api.elsevier.com/content/search/scopus";
+	private static final String AUTHOR_SEARCH = "https://api.elsevier.com/content/search/author";
+
+	/** Scopus returns at most this many documents per request; the JSON's total reports the real count. */
+	private static final int DOCUMENT_PAGE_SIZE = 200;
+	private static final int AUTHOR_PAGE_SIZE = 10;
+	private static final String DEFAULT_AFFILIATION = "Weill Cornell";
+
+	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(60);
+
+	// Same credentials the retrieval path uses (injected into the deployment as env/secret).
+	private static final String INST_TOKEN = System.getenv("SCOPUS_INST_TOKEN");
+	private static final String API_KEY = System.getenv("SCOPUS_API_KEY");
+
+	private final HttpClient httpClient;
+
+	public ScopusSearchService() {
+		this.httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+		if (API_KEY == null || INST_TOKEN == null) {
+			slf4jLogger.warn("SCOPUS_API_KEY and/or SCOPUS_INST_TOKEN are not set; "
+					+ "Scopus search requests will be rejected until they are configured.");
+		}
+	}
+
+	/** True once both Elsevier credentials are present; the controller returns 503 otherwise. */
+	public boolean isConfigured() {
+		return API_KEY != null && INST_TOKEN != null;
+	}
+
+	/**
+	 * Search Scopus documents. {@code by} selects the query field:
+	 * {@code keyword} → TITLE-ABS-KEY (relevance order), {@code doi} → DOI, anything else
+	 * → AU-ID (author id, newest first). Returns Elsevier's {@code search-results} JSON.
+	 */
+	public HttpResponse<String> searchDocuments(String by, String term)
+			throws IOException, InterruptedException {
+		String t = term == null ? "" : term.trim();
+		String query;
+		String sort = "&sort=-coverDate";
+		if ("keyword".equals(by)) {
+			query = "TITLE-ABS-KEY(" + t + ")";
+			sort = ""; // relevance order
+		} else if ("doi".equals(by)) {
+			query = "DOI(" + t + ")";
+		} else {
+			query = "AU-ID(" + t.replaceFirst("(?i)^AUTHOR_ID:", "") + ")";
+		}
+		String url = SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort;
+		return get(url);
+	}
+
+	/**
+	 * Search Scopus authors by name, scoped to an affiliation (defaults to Weill Cornell).
+	 * Returns Elsevier's {@code search-results} JSON of author profiles.
+	 */
+	public HttpResponse<String> searchAuthors(String lastName, String firstName, String affiliation)
+			throws IOException, InterruptedException {
+		StringBuilder q = new StringBuilder("authlast(").append(nullToEmpty(lastName).trim()).append(")");
+		String first = nullToEmpty(firstName).trim();
+		if (!first.isEmpty()) {
+			q.append(" AND authfirst(").append(first).append(")");
+		}
+		String affil = nullToEmpty(affiliation).trim();
+		q.append(" AND affil(").append(affil.isEmpty() ? DEFAULT_AFFILIATION : affil).append(")");
+		String url = AUTHOR_SEARCH + "?query=" + enc(q.toString()) + "&count=" + AUTHOR_PAGE_SIZE;
+		return get(url);
+	}
+
+	private HttpResponse<String> get(String url) throws IOException, InterruptedException {
+		slf4jLogger.info("Scopus search: {}", url);
+		HttpRequest.Builder builder = HttpRequest.newBuilder()
+				.uri(URI.create(url))
+				.timeout(REQUEST_TIMEOUT)
+				.header("Accept", "application/json")
+				.GET();
+		builder.header("X-ELS-Insttoken", INST_TOKEN);
+		builder.header("X-ELS-APIKey", API_KEY);
+		return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+	}
+
+	private static String enc(String s) {
+		return URLEncoder.encode(s, StandardCharsets.UTF_8);
+	}
+
+	private static String nullToEmpty(String s) {
+		return s == null ? "" : s;
+	}
+}

--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -88,6 +88,54 @@ public class ScopusSearchService {
 	}
 
 	/**
+	 * Elsevier's page-size ceilings, which differ BY VIEW. Probed against the live API rather than
+	 * read off a page: with {@code view=COMPLETE}, {@code count=50} and {@code count=200} both come
+	 * back <strong>HTTP 400 INVALID_INPUT</strong> — not a truncated page, a refusal. So a caller
+	 * who wants more than 25 COMPLETE records must PAGE with {@code start}; there is no single call
+	 * that will do it, and pretending otherwise is how you end up printing "top 50" over 25 records.
+	 */
+	public static final int MAX_COUNT_COMPLETE = 25;
+	public static final int MAX_COUNT_STANDARD = 200;
+
+	/** The ceiling that applies to a given view. */
+	public static int maxCountFor(String view) {
+		return view != null && "COMPLETE".equalsIgnoreCase(view.trim()) ? MAX_COUNT_COMPLETE : MAX_COUNT_STANDARD;
+	}
+
+	/**
+	 * Search Scopus with the query passed through <strong>VERBATIM</strong>.
+	 *
+	 * <p>This is the whole point of this method, and the difference between it and
+	 * {@link #searchDocuments}: that one force-wraps the caller's terms in
+	 * {@code TITLE-ABS-KEY(...)}, so a caller can never express a TOP-LEVEL limit. Nest
+	 * {@code PUBYEAR > 2020} inside {@code TITLE-ABS-KEY()} and Elsevier answers
+	 * {@code HTTP 400 "Error translating query"} — loudly, which is the good news, but it means the
+	 * wrapped endpoint simply cannot run a real search strategy. Verified against the live API:
+	 * passed raw, a query narrows exactly as a librarian expects
+	 * (2,900 → {@code AND PUBYEAR > 2020} → 1,958 → {@code AND DOCTYPE(ar)} → 1,376).
+	 *
+	 * <p>The caller writes native Scopus. NOTHING here translates a query from another database's
+	 * syntax, and nothing ever should: Cochrane and PRESS expect a bespoke, separately peer-reviewed
+	 * strategy per database, and a mechanical MeSH → Scopus transliteration is exactly the artifact
+	 * a librarian would reject at review.
+	 *
+	 * <p>To COUNT without retrieving, ask for {@code count=1} and read
+	 * {@code search-results.opensearch:totalResults}. Not {@code count=0} — Elsevier ignores that
+	 * and silently returns 25 records.
+	 */
+	public HttpResponse<String> searchRaw(String query, int count, int start, String view)
+			throws IOException, InterruptedException {
+		StringBuilder url = new StringBuilder(SCOPUS_SEARCH)
+				.append("?query=").append(enc(query.trim()))
+				.append("&count=").append(count)
+				.append("&start=").append(start);
+		if (!nullToEmpty(view).trim().isEmpty()) {
+			url.append("&view=").append(enc(view.trim().toUpperCase()));
+		}
+		return get(url.toString());
+	}
+
+	/**
 	 * Search Scopus authors by name, scoped to an affiliation (defaults to Weill Cornell).
 	 * Returns Elsevier's {@code search-results} JSON of author profiles.
 	 */

--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -39,6 +39,13 @@ public class ScopusSearchService {
 	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
 	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(60);
 
+	// Elsevier intermittently resets the connection under load; retry the transient I/O a
+	// few times (short backoff) so a reset surfaces as a result rather than a 502. The
+	// article-retrieval path retries similarly (via guava-retrying); this is the lightweight
+	// equivalent for a single synchronous search request.
+	private static final int MAX_ATTEMPTS = 3;
+	private static final long RETRY_BACKOFF_MS = 250L;
+
 	// Same credentials the retrieval path uses (injected into the deployment as env/secret).
 	private static final String INST_TOKEN = System.getenv("SCOPUS_INST_TOKEN");
 	private static final String API_KEY = System.getenv("SCOPUS_API_KEY");
@@ -99,14 +106,29 @@ public class ScopusSearchService {
 
 	private HttpResponse<String> get(String url) throws IOException, InterruptedException {
 		slf4jLogger.info("Scopus search: {}", url);
-		HttpRequest.Builder builder = HttpRequest.newBuilder()
+		HttpRequest request = HttpRequest.newBuilder()
 				.uri(URI.create(url))
 				.timeout(REQUEST_TIMEOUT)
 				.header("Accept", "application/json")
-				.GET();
-		builder.header("X-ELS-Insttoken", INST_TOKEN);
-		builder.header("X-ELS-APIKey", API_KEY);
-		return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+				.header("X-ELS-Insttoken", INST_TOKEN)
+				.header("X-ELS-APIKey", API_KEY)
+				.GET()
+				.build();
+		IOException last = null;
+		for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			try {
+				return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+			} catch (IOException e) {
+				// Transient (connection reset, timeout) — retry; a permanent failure still
+				// throws after the last attempt and the controller maps it to 502.
+				last = e;
+				slf4jLogger.warn("Scopus search attempt {}/{} failed ({}); retrying", attempt, MAX_ATTEMPTS, e.toString());
+				if (attempt < MAX_ATTEMPTS) {
+					Thread.sleep(RETRY_BACKOFF_MS * attempt);
+				}
+			}
+		}
+		throw last;
 	}
 
 	private static String enc(String s) {

--- a/src/test/java/reciter/controller/ScopusSearchQueryValidationTest.java
+++ b/src/test/java/reciter/controller/ScopusSearchQueryValidationTest.java
@@ -1,0 +1,93 @@
+package reciter.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.scopus.search.ScopusSearchRequest;
+import reciter.scopus.search.ScopusSearchService;
+
+/**
+ * Unit tests for {@link ScopusSearchController#validate} — the guard on the verbatim-query
+ * endpoint.
+ *
+ * <p>Every rule pinned here is one where Elsevier's own behaviour would otherwise hand the caller a
+ * confidently WRONG answer rather than an error, so a regression would be invisible:
+ *
+ * <ul>
+ *   <li>{@code count=0} is IGNORED by Elsevier, which returns 25 records — so "just give me the
+ *       total" must be {@code count=1}, and a zero has to be refused rather than passed on.</li>
+ *   <li>{@code view=COMPLETE} caps a page at 25. Both of these were probed against the live API:
+ *       {@code count=50&view=COMPLETE} is an HTTP 400, not a short page.</li>
+ * </ul>
+ */
+class ScopusSearchQueryValidationTest {
+
+	private static ScopusSearchRequest req(String query, Integer count, Integer start, String view) {
+		return new ScopusSearchRequest(query, count, start, view);
+	}
+
+	private static String messageOf(ScopusSearchRequest r) {
+		return assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(r)).getMessage();
+	}
+
+	@Test
+	void acceptsAStrategyWithTopLevelLimits() {
+		// The whole reason this endpoint exists: a top-level limit that TITLE-ABS-KEY() cannot hold.
+		assertDoesNotThrow(() -> ScopusSearchController.validate(
+				req("TITLE-ABS-KEY(probiotics AND depression) AND PUBYEAR > 2020 AND DOCTYPE(ar)", null, null, null)));
+	}
+
+	@Test
+	void rejectsMissingQuery() {
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(null));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req(null, null, null, null)));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("   ", null, null, null)));
+	}
+
+	/** count=0 is not "no records" — Elsevier ignores it and sends 25. Refuse it, and say so. */
+	@Test
+	void rejectsZeroCountAndSaysWhatToUseInstead() {
+		String msg = messageOf(req("probiotics", 0, null, null));
+		assertTrue(msg.contains("count=1"), "the error must point at the cheap-count idiom, got: " + msg);
+	}
+
+	/** The COMPLETE ceiling is 25, and a caller asking for 50 must be TOLD, not quietly given 25. */
+	@Test
+	void rejectsOversizedCompletePageRatherThanClampingIt() {
+		String msg = messageOf(req("probiotics", 50, null, "COMPLETE"));
+		assertTrue(msg.contains("25"), "the error must name the COMPLETE ceiling, got: " + msg);
+		assertTrue(msg.contains("start"), "the error must say how to get the rest, got: " + msg);
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 25, null, "COMPLETE")));
+		// 50 records at COMPLETE is two pages, and both of them are legal.
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 25, 25, "COMPLETE")));
+	}
+
+	/** STANDARD is a different ceiling, so the same count is fine there. */
+	@Test
+	void standardViewAllowsTwoHundred() {
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 200, null, null)));
+		assertDoesNotThrow(() -> ScopusSearchController.validate(req("probiotics", 200, null, "STANDARD")));
+		assertTrue(messageOf(req("probiotics", 201, null, "STANDARD")).contains("200"));
+		assertEquals(200, ScopusSearchService.maxCountFor(null));
+		assertEquals(200, ScopusSearchService.maxCountFor("STANDARD"));
+		assertEquals(25, ScopusSearchService.maxCountFor("complete"));   // case-insensitive, like Elsevier
+	}
+
+	@Test
+	void rejectsUnknownViewAndNegativeStart() {
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("x", null, null, "FULL")));
+		assertThrows(IllegalArgumentException.class, () -> ScopusSearchController.validate(req("x", null, -1, null)));
+	}
+
+	/** The default page has to be legal in EITHER view, or an unset count breaks COMPLETE. */
+	@Test
+	void defaultCountIsSafeInBothViews() {
+		assertEquals(25, req("x", null, null, null).countOrDefault());
+		assertEquals(0, req("x", null, null, null).startOrDefault());
+		assertTrue(ScopusSearchRequest.DEFAULT_COUNT <= ScopusSearchService.MAX_COUNT_COMPLETE);
+	}
+}


### PR DESCRIPTION
## Why

PM's Scopus Authorships tab returns "No Scopus documents matched" for every person in prod. The cause is on this side — `reciter-scopus-prod` **404s** the routes PM calls:

```
GET http://reciter-scopus-prod/scopus/search/documents?by=author&term=57202614648
→ HTTP/1.1 404
```

The endpoints (#31, #34, #35) merged to `dev` on 2026-07-10..13 and never reached the branch prod's image is built from.

## Why this branch and not master

`master` is 63 commits **behind** — it predates the Corretto 17 migration. Building prod from `master` today would ship an *older* image than the one running, so the fix targets `MigrationFromJDk11ToAWSCorretto17`, which is what produced the deployed image (`...-54.2026-07-03.5fab097e`) and which the buildspec already deploys to `reciter-scopus-prod`.

Untangling `master` is worth doing, but not in the same change as a prod hotfix.

## What

Three commits cherry-picked from `dev`, clean, no conflicts:

| Commit | |
|---|---|
| `b5dc5b7` | authenticated Scopus search proxy endpoints |
| `b5aab00` | retry transient Elsevier connection resets |
| `9302daa` | pass a Scopus query through verbatim |

```
4 files changed, 503 insertions(+), 0 deletions(-)

NEW  ScopusSearchController.java           +178
NEW  ScopusSearchService.java              +189
NEW  ScopusSearchRequest.java               +43
NEW  ScopusSearchQueryValidationTest.java   +93
```

**Every file is new. Nothing existing is modified** — no change to `ScopusXmlHandler`, `ScopusArticleRetriever`, `ScopusXmlQuery`, `ScopusController`, `pom.xml`, or the k8s manifest. The nightly retrieval path that feeds ReCiterDB is untouched, so this deploy has exactly one thing to blame if anything moves.

Verified locally against this branch's code, confirming the endpoints don't depend on the `@Service` refactor on dev:

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Deliberately left on dev for a separate release

`dev` also carries real bug fixes to the retrieval path — SAX parser field leakage between Scopus entries and text truncation (`5b2bbc1`, `d359d17`), the retriever refactor with partial results (`f432b05`), and request validation returning 400 instead of 500 (`67bf3d5`). Those are worth shipping, but they change what ReCiter ingests nightly and deserve their own deploy with a nightly run watched against them.

## This PR alone does not fix prod

PM also needs `RECITER_SCOPUS_API_URL=http://reciter-scopus-prod` on the `reciter-pm-prod` deployment — it is unset, so PM builds the literal URL `"undefined/scopus/search/documents"`, the fetch throws, and the tab renders the 502 as "No Scopus documents matched". PM prod deploys via `set image` only, so that is a `kubectl set env`, not a PR. Documented in the PM repo's `HANDOFF-scopus-pubmed-tools.md:25`. Merge this first — setting the var earlier only turns a silent "no match" into a 502.