### PR TITLE
Return every author on a document search, not just dc:creator

### DIFF
--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -33,6 +33,21 @@ public class ScopusSearchService {
 
 	/** Scopus returns at most this many documents per request; the JSON's total reports the real count. */
 	private static final int DOCUMENT_PAGE_SIZE = 200;
+
+	/**
+	 * Fields requested for a document search. {@code field} is a WHITELIST — anything omitted here
+	 * is absent from the response — so this list must cover everything a caller reads.
+	 *
+	 * <p>Its real job is {@code author}. The default view populates only {@code dc:creator}, the
+	 * FIRST author, so a three-author chapter came back as one name. The obvious fix,
+	 * {@code view=COMPLETE}, is a trap: it caps a page at {@link #MAX_COUNT_COMPLETE} and REFUSES
+	 * {@code count=200} with HTTP 400 (see below), so it would trade missing authors for missing
+	 * documents, or force paging. Asking for {@code author} by field returns the full author array
+	 * at {@code count=200} in a single call — probed live: 117/117 entries carried it.
+	 */
+	private static final String DOCUMENT_FIELDS = String.join(",",
+			"dc:identifier", "dc:title", "dc:creator", "author", "prism:doi",
+			"prism:coverDate", "prism:publicationName", "pubmed-id", "subtypeDescription");
 	private static final int AUTHOR_PAGE_SIZE = 10;
 	private static final String DEFAULT_AFFILIATION = "Weill Cornell";
 
@@ -72,6 +87,11 @@ public class ScopusSearchService {
 	 */
 	public HttpResponse<String> searchDocuments(String by, String term)
 			throws IOException, InterruptedException {
+		return get(buildDocumentSearchUrl(by, term));
+	}
+
+	/** Package-private so the field whitelist and the page size can be pinned by a test. */
+	static String buildDocumentSearchUrl(String by, String term) {
 		String t = term == null ? "" : term.trim();
 		String query;
 		String sort = "&sort=-coverDate";
@@ -83,8 +103,8 @@ public class ScopusSearchService {
 		} else {
 			query = "AU-ID(" + t.replaceFirst("(?i)^AUTHOR_ID:", "") + ")";
 		}
-		String url = SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort;
-		return get(url);
+		return SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort
+				+ "&field=" + enc(DOCUMENT_FIELDS);
 	}
 
 	/**

--- a/src/test/java/reciter/scopus/search/ScopusDocumentSearchUrlTest.java
+++ b/src/test/java/reciter/scopus/search/ScopusDocumentSearchUrlTest.java
@@ -1,0 +1,63 @@
+package reciter.scopus.search;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the document-search URL, whose two halves each fail SILENTLY if broken.
+ *
+ * <p>A document search that drops {@code author} from the field whitelist still returns HTTP 200
+ * and a full page of documents — only every author list collapses to the first name, which is what
+ * put a three-author book chapter on screen as "Proal A.D.". Conversely, reaching for
+ * {@code view=COMPLETE} to get those authors caps a page at 25 and refuses {@code count=200} with
+ * an HTTP 400. Neither shows up as a test failure anywhere else.
+ */
+class ScopusDocumentSearchUrlTest {
+
+	@Test
+	void requestsTheAuthorArray() {
+		// The bug this fixes: without an explicit `author` field the response carries only dc:creator.
+		String url = ScopusSearchService.buildDocumentSearchUrl("author", "23493733900");
+		assertTrue(url.contains("field="), "document search must restrict fields, or `author` is absent");
+		assertTrue(fieldList(url).contains("author"), "field whitelist must request the full author array");
+	}
+
+	@Test
+	void keepsEveryFieldTheCallerReads() {
+		// `field` is a whitelist: anything missing here is absent from the response. PM drops any
+		// entry without dc:identifier, so an omission here empties the results tab.
+		String fields = fieldList(ScopusSearchService.buildDocumentSearchUrl("author", "23493733900"));
+		for (String required : new String[] { "dc:identifier", "dc:title", "dc:creator", "author",
+				"prism:doi", "prism:coverDate", "prism:publicationName", "pubmed-id", "subtypeDescription" }) {
+			assertTrue(fields.contains(required), "field whitelist is missing " + required);
+		}
+	}
+
+	@Test
+	void doesNotPayForAuthorsWithTheCompleteViewCeiling() {
+		// view=COMPLETE would return authors too, but caps a page at 25 and 400s on count=200 —
+		// trading missing authors for missing documents. Probed live; see ScopusSearchService.
+		String url = ScopusSearchService.buildDocumentSearchUrl("author", "23493733900");
+		assertFalse(url.contains("view=COMPLETE"), "COMPLETE view refuses count=200");
+		assertTrue(url.contains("count=200"), "a prolific author's full result set must fit one call");
+	}
+
+	@Test
+	void stillBuildsTheThreeQueryShapes() {
+		assertTrue(ScopusSearchService.buildDocumentSearchUrl("author", "AUTHOR_ID:23493733900")
+				.contains("AU-ID%2823493733900%29"), "author search must strip the AUTHOR_ID: prefix");
+		assertTrue(ScopusSearchService.buildDocumentSearchUrl("doi", "10.1016/j.autrev.2009.02.011")
+				.contains("DOI%28"), "doi search must use the DOI() field");
+		String keyword = ScopusSearchService.buildDocumentSearchUrl("keyword", "vitamin d");
+		assertTrue(keyword.contains("TITLE-ABS-KEY%28"), "keyword search must use TITLE-ABS-KEY()");
+		assertFalse(keyword.contains("sort="), "keyword search stays in relevance order");
+	}
+
+	/** The decoded value of the field= parameter. */
+	private static String fieldList(String url) {
+		int i = url.indexOf("field=");
+		return i < 0 ? "" : url.substring(i + "field=".length()).replace("%3A", ":").replace("%2C", ",");
+	}
+}


### PR DESCRIPTION
## The bug

A Scopus result showed one author where the publisher shows three:

```
PM card       Proal A.D.
ScienceDirect Amy D. Proal, Paul J. Albert, Trevor G. Marshall
              Infection, Autoimmunity, and Vitamin D  (10.1016/B978-0-444-63269-2.00007-6)
```

A document search populates `dc:creator`, which is the **first author only**. It is not a display nit: PM's `normalizeScopusDoc` puts that single name into the external-article POST body, so accepting a Scopus-only item **persists** a one-author record.

## Why `field=`, not `view=COMPLETE`

`view=COMPLETE` returns the author array too, and is entitled — but it caps a page at 25 and **refuses** `count=200` outright, which this repo already documents from an earlier live probe. Re-confirmed against prod credentials:

```
count=200&view=COMPLETE          → HTTP 400
count=25&view=COMPLETE           → HTTP 200
count=25&start=25&view=COMPLETE  → HTTP 200   (paging works)
count=200  (default view)        → HTTP 200
```

So COMPLETE would trade missing authors for missing documents — a prolific author's 117 results become 25 — or force a paging loop. Asking for `author` by field costs neither:

```
count=200&field=dc:identifier,...,author
  → totalResults 117, entries 117, entries carrying an author array: 117
```

One call, full result set, full authors. Verified on the reported record:

```
Infection, Autoimmunity, and Vitamin D
  authors = ['Proal A.D.', 'Albert P.J.', 'Marshall T.G.']
```

## What changed

`field` is a **whitelist** — anything not named is absent from the response — so the list covers every field a caller reads. PM drops entries lacking `dc:identifier`, so an omission there would empty the results tab rather than degrade it.

The URL builder is now package-private and pinned by `ScopusDocumentSearchUrlTest`, because both failure modes are silent: dropping `author` still returns HTTP 200 and a full page of documents, and reaching for COMPLETE only breaks once `count` exceeds 25. Neither would surface as a failure anywhere else.

```
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Pairs with

The PM-side change that reads the array — otherwise the tool returns the authors and PM keeps rendering `dc:creator`. Both are needed for the card to change.

## Note on prod

Prod's Scopus tool builds from `MigrationFromJDk11ToAWSCorretto17`, not `dev` (see #37), so this needs the same cherry-pick to reach `reciter-scopus-prod` after it is verified on `reciter-scopus-dev`.