### PR TITLE
Return every author on a document search (prod)

### DIFF
--- a/src/main/java/reciter/scopus/search/ScopusSearchService.java
+++ b/src/main/java/reciter/scopus/search/ScopusSearchService.java
@@ -33,6 +33,21 @@ public class ScopusSearchService {
 
 	/** Scopus returns at most this many documents per request; the JSON's total reports the real count. */
 	private static final int DOCUMENT_PAGE_SIZE = 200;
+
+	/**
+	 * Fields requested for a document search. {@code field} is a WHITELIST — anything omitted here
+	 * is absent from the response — so this list must cover everything a caller reads.
+	 *
+	 * <p>Its real job is {@code author}. The default view populates only {@code dc:creator}, the
+	 * FIRST author, so a three-author chapter came back as one name. The obvious fix,
+	 * {@code view=COMPLETE}, is a trap: it caps a page at {@link #MAX_COUNT_COMPLETE} and REFUSES
+	 * {@code count=200} with HTTP 400 (see below), so it would trade missing authors for missing
+	 * documents, or force paging. Asking for {@code author} by field returns the full author array
+	 * at {@code count=200} in a single call — probed live: 117/117 entries carried it.
+	 */
+	private static final String DOCUMENT_FIELDS = String.join(",",
+			"dc:identifier", "dc:title", "dc:creator", "author", "prism:doi",
+			"prism:coverDate", "prism:publicationName", "pubmed-id", "subtypeDescription");
 	private static final int AUTHOR_PAGE_SIZE = 10;
 	private static final String DEFAULT_AFFILIATION = "Weill Cornell";
 
@@ -72,6 +87,11 @@ public class ScopusSearchService {
 	 */
 	public HttpResponse<String> searchDocuments(String by, String term)
 			throws IOException, InterruptedException {
+		return get(buildDocumentSearchUrl(by, term));
+	}
+
+	/** Package-private so the field whitelist and the page size can be pinned by a test. */
+	static String buildDocumentSearchUrl(String by, String term) {
 		String t = term == null ? "" : term.trim();
 		String query;
 		String sort = "&sort=-coverDate";
@@ -83,8 +103,8 @@ public class ScopusSearchService {
 		} else {
 			query = "AU-ID(" + t.replaceFirst("(?i)^AUTHOR_ID:", "") + ")";
 		}
-		String url = SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort;
-		return get(url);
+		return SCOPUS_SEARCH + "?query=" + enc(query) + "&count=" + DOCUMENT_PAGE_SIZE + sort
+				+ "&field=" + enc(DOCUMENT_FIELDS);
 	}
 
 	/**

--- a/src/test/java/reciter/scopus/search/ScopusDocumentSearchUrlTest.java
+++ b/src/test/java/reciter/scopus/search/ScopusDocumentSearchUrlTest.java
@@ -1,0 +1,63 @@
+package reciter.scopus.search;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the document-search URL, whose two halves each fail SILENTLY if broken.
+ *
+ * <p>A document search that drops {@code author} from the field whitelist still returns HTTP 200
+ * and a full page of documents — only every author list collapses to the first name, which is what
+ * put a three-author book chapter on screen as "Proal A.D.". Conversely, reaching for
+ * {@code view=COMPLETE} to get those authors caps a page at 25 and refuses {@code count=200} with
+ * an HTTP 400. Neither shows up as a test failure anywhere else.
+ */
+class ScopusDocumentSearchUrlTest {
+
+	@Test
+	void requestsTheAuthorArray() {
+		// The bug this fixes: without an explicit `author` field the response carries only dc:creator.
+		String url = ScopusSearchService.buildDocumentSearchUrl("author", "23493733900");
+		assertTrue(url.contains("field="), "document search must restrict fields, or `author` is absent");
+		assertTrue(fieldList(url).contains("author"), "field whitelist must request the full author array");
+	}
+
+	@Test
+	void keepsEveryFieldTheCallerReads() {
+		// `field` is a whitelist: anything missing here is absent from the response. PM drops any
+		// entry without dc:identifier, so an omission here empties the results tab.
+		String fields = fieldList(ScopusSearchService.buildDocumentSearchUrl("author", "23493733900"));
+		for (String required : new String[] { "dc:identifier", "dc:title", "dc:creator", "author",
+				"prism:doi", "prism:coverDate", "prism:publicationName", "pubmed-id", "subtypeDescription" }) {
+			assertTrue(fields.contains(required), "field whitelist is missing " + required);
+		}
+	}
+
+	@Test
+	void doesNotPayForAuthorsWithTheCompleteViewCeiling() {
+		// view=COMPLETE would return authors too, but caps a page at 25 and 400s on count=200 —
+		// trading missing authors for missing documents. Probed live; see ScopusSearchService.
+		String url = ScopusSearchService.buildDocumentSearchUrl("author", "23493733900");
+		assertFalse(url.contains("view=COMPLETE"), "COMPLETE view refuses count=200");
+		assertTrue(url.contains("count=200"), "a prolific author's full result set must fit one call");
+	}
+
+	@Test
+	void stillBuildsTheThreeQueryShapes() {
+		assertTrue(ScopusSearchService.buildDocumentSearchUrl("author", "AUTHOR_ID:23493733900")
+				.contains("AU-ID%2823493733900%29"), "author search must strip the AUTHOR_ID: prefix");
+		assertTrue(ScopusSearchService.buildDocumentSearchUrl("doi", "10.1016/j.autrev.2009.02.011")
+				.contains("DOI%28"), "doi search must use the DOI() field");
+		String keyword = ScopusSearchService.buildDocumentSearchUrl("keyword", "vitamin d");
+		assertTrue(keyword.contains("TITLE-ABS-KEY%28"), "keyword search must use TITLE-ABS-KEY()");
+		assertFalse(keyword.contains("sort="), "keyword search stays in relevance order");
+	}
+
+	/** The decoded value of the field= parameter. */
+	private static String fieldList(String url) {
+		int i = url.indexOf("field=");
+		return i < 0 ? "" : url.substring(i + "field=".length()).replace("%3A", ":").replace("%2C", ",");
+	}
+}


### PR DESCRIPTION
## What

Cherry-pick of `6267fbc` from #38, already merged to `dev` and running on `reciter-scopus-dev`.

```
2 files changed, 85 insertions(+), 2 deletions(-)
  ScopusSearchService.java            +24   field whitelist + package-private URL builder
  ScopusDocumentSearchUrlTest.java    +63   new
```

Applied with no conflicts. `mvn clean test` on this branch: **Tests run: 11, Failures: 0 — BUILD SUCCESS**.

## Why it matters more in prod than it looks

A document search populates `dc:creator`, the **first author only**. PM's `normalizeScopusDoc` puts that single name into the external-article POST body, so accepting a Scopus-only item **persists** a one-author record.

That is not hypothetical. A scan of the `ExternalArticle` DynamoDB table:

```
Scopus-accepted rows        120   across 91 people
truly multi-author          115
genuinely single-author       5
author names lost           721   max 28 on one record, median 6
```

Prod and dev ReCiter read the **same** table, so those records are live in prod. Prod's Scopus tab only became usable today (#37 plus the missing `RECITER_SCOPUS_API_URL`), so every acceptance from here adds to that count until this ships.

## Why `field=`, not `view=COMPLETE`

COMPLETE carries the author array but caps a page at 25 and refuses `count=200` with HTTP 400 — it would trade missing authors for missing documents. The field whitelist returns all 117 of a prolific author's records with full authors in one call. Probed live against these credentials; full numbers in #38.

## Deploy order

**This first, then PM.** PM cannot read an author array the tool does not return.

## Note on CI

This branch has no `.github/workflows/ci.yml` — it was added on `dev` and never came across — so GitHub reports no checks here. The evidence is the local run above. The branch's buildspec also runs `mvn clean install -Dmaven.test.skip=true`, so CodeBuild will not run the new test either.